### PR TITLE
1.1 Upgrade pegdown to 0.9.0

### DIFF
--- a/project/build/project.scala
+++ b/project/build/project.scala
@@ -19,8 +19,7 @@ class Project(info: ProjectInfo) extends DefaultProject(info) with ScctProject w
   val hamcrest      = "org.hamcrest" % "hamcrest-all" % "1.1"
   val mockito 	 	= "org.mockito" % "mockito-all" % "1.8.5" 
   val junit     	= "junit" % "junit" % "4.7"
-  val parboiled     =  "org.parboiled" % "parboiled4j" % "0.9.9.0"
-  val pegdown       =  "org.pegdown" % "pegdown" % "0.8.5.4"
+  val pegdown       =  "org.pegdown" % "pegdown" % "0.9.0"
   
   override protected def docAction = scaladocTask(mainLabel, mainSources, mainDocPath, docClasspath, documentOptions)
   


### PR DESCRIPTION
Eric,
just tried building specs2 1.1 with pegdown 0.9.0... I did not come across any issues.
SBT compiles, tests and packages everything without any problems.

Am I missing something?
