### PR TITLE
delete Iterablex Extractors

### DIFF
--- a/src/main/scala/org/specs2/collection/Iterablex.scala
+++ b/src/main/scala/org/specs2/collection/Iterablex.scala
@@ -117,26 +117,4 @@ trait Iterablex {
   }
 }
 
-object Iterablex extends Iterablex {
-  import scala.collection.SeqLike
-
-  /**
-   * extractor object to extract the first element of a sequence
-   *
-   * l match { case e +: rest => ok }
-   */
-  object +: {
-    def unapply[A, C <: SeqLike[A, C]](seq: C with SeqLike[A, C]) =
-      seq.headOption.map(h => (h, seq.tail))
-  }
-
-  /**
-   * extractor object to extract the last element of a sequence
-   *
-   * l match { case init :+ last => ok }
-   */
-  object :+ {
-    def unapply[A, C <: SeqLike[A, C]](seq: C with SeqLike[A, C]) =
-      seq.headOption.map(h => (seq.init, seq.last ))
-  }
-}
+object Iterablex extends Iterablex

--- a/src/test/scala/org/specs2/collection/IterablexSpec.scala
+++ b/src/test/scala/org/specs2/collection/IterablexSpec.scala
@@ -52,9 +52,6 @@ class IterablexSpec extends Specification with IterableData {
   "mapLast maps the last element with a function if it exists" in
   { Seq(1, 2).mapLast(_ + 1) must_== Seq(1, 3) }
 
-  "a seq can be matched on its last element" in
-  { Seq(1, 2, 3) must beLike { case init :+ last => ok; case _ => ko } }
-
 }
 
 import org.scalacheck.Arbitrary


### PR DESCRIPTION
There are in Scala std from 2.10.0
https://github.com/scala/scala/blob/v2.10.0/src/library/scala/collection/SeqExtractors.scala
