### PR TITLE
use wiki syntax instead of <code> tag

### DIFF
--- a/src/main/scala/org/specs2/control/LazyParameter.scala
+++ b/src/main/scala/org/specs2/control/LazyParameter.scala
@@ -5,14 +5,14 @@ import Exceptions._
 
 /**
  * This trait can be used to allow some function to be called with varargs, with values being
- * evaluated lazily:<code>
- * 
+ * evaluated lazily:
+ * {{{
  *   def method[T](values: LazyParameter[T]*) = {
  *     values.toStream // use the toStream method to consume the values lazily
  *   }
  *   // usage
  *   method(exp1, exp2, exp3)
- * </code>
+ * }}}
  *
  * Note that the values are really evaluated once, unlike a by-name parameter.
  */

--- a/src/main/scala/org/specs2/io/FileSystem.scala
+++ b/src/main/scala/org/specs2/io/FileSystem.scala
@@ -8,13 +8,13 @@ import java.util.zip._
 /**
  * The FileSystem trait abstracts file system operations to allow easier mocking of file system related functionalities.
  * <p>
- * It mixes the <code>FileReader</code> and <code>FileWriter</code> traits to provide easy read/write operations.  
+ * It mixes the `FileReader` and `FileWriter` traits to provide easy read/write operations.
  */
 private[specs2]
 trait FileSystem extends org.specs2.io.FileReader with org.specs2.io.FileWriter {
   /**
-   * @param path glob expression, for example: <code>./dir/**/*.xml</code>
-   * @return the list of paths represented by the "glob" definition <code>path</code>
+   * @param path glob expression, for example: `./dir/**/*.xml`
+   * @return the list of paths represented by the "glob" definition `path`
    */
   def filePaths(basePath: String = ".", path: String = "*", verbose: Boolean = false): Seq[String] = {
     val found = recurse(new File(basePath))

--- a/src/main/scala/org/specs2/io/FileWriter.scala
+++ b/src/main/scala/org/specs2/io/FileWriter.scala
@@ -15,11 +15,12 @@ trait FileWriter {
 
   /**
    * writes some content to a file and take care of closing the file.<p>
-   * Usage: <code>
+   * Usage:
+   * {{{
    * write("./dir/hello.txt") { out =>
    *   out.write("content")
    * }
-   * </code>
+   * }}}
    * @param path path of the file to write
    */
   def write(path: String)(function: Writer => Unit): Unit = {
@@ -28,11 +29,12 @@ trait FileWriter {
   }
   /**
    * append some content to a file and take care of closing the file.<p>
-   * Usage: <code>
+   * Usage:
+   * {{{
    * write("./dir/hello.txt") { out =>
    *   out.write("content")
    * }
-   * </code>
+   * }}}
    * @param path path of the file to write
    */
   def append(path: String)(function: Writer => Unit): Unit = {
@@ -91,7 +93,7 @@ trait FileWriter {
 
   /**
    * The getWriter function can be overriden to provide a mock writer writing to the console for example
-   * @return a Writer object opened on the file designated by <code>path</code>
+   * @return a Writer object opened on the file designated by `path`
    */
   def getWriter(path: String, append: Boolean = false): Writer =
     new BufferedWriter(new OutputStreamWriter(new FileOutputStream(path, append), Charset.forName(getOrElse("specs2.file.encoding", "UTF-8"))))

--- a/src/main/scala/org/specs2/matcher/Matcher.scala
+++ b/src/main/scala/org/specs2/matcher/Matcher.scala
@@ -15,7 +15,7 @@ import MatchResultLogicalCombinators._
 /**
  * The `Matcher` trait is the base trait for any Matcher.
  * 
- * This trait can be extended to provide an appropriate <code>apply</code> method that
+ * This trait can be extended to provide an appropriate `apply` method that
  * will check an expectable value `a: Expectable[T]`.
  *
  * The result of a match is a MatchResult object (@see MatchResult).
@@ -180,7 +180,7 @@ trait Matcher[-T] { outer =>
     def apply[U <: T](a: Expectable[U]) = if (b) outer(a) else outer(a).not
   }
   /**
-   *  The <code>lazily</code> operator returns a Matcher which will match a function returning the expected value
+   *  The `lazily` operator returns a Matcher which will match a function returning the expected value
    */   
   def lazily = new Matcher[() => T]() {
     def apply[S <: () => T](function: Expectable[S]) = {

--- a/src/main/scala/org/specs2/matcher/MatchersImplicits.scala
+++ b/src/main/scala/org/specs2/matcher/MatchersImplicits.scala
@@ -100,8 +100,11 @@ trait MatchersImplicits extends Expectations with MatchResultCombinators with Ma
   }
 
   /**
-   * The <code>SeqMatcher</code> class is a matcher matching a sequence of objects with a matcher returned by a function.<p>
-   * Usage:<code>List(1, 2, 3) must ((beEqualTo(_:Int)).toSeq)(List(1, 2, 3)) </code>
+   * The `SeqMatcher` class is a matcher matching a sequence of objects with a matcher returned by a function.<p>
+   * Usage:
+   * {{{
+   * List(1, 2, 3) must ((beEqualTo(_:Int)).toSeq)(List(1, 2, 3))
+   * }}}
    */
   class SeqMatcher[S, T](s: Seq[S], f: S => Matcher[T]) extends Matcher[Seq[T]] {
     def apply[U <: Seq[T]](t: Expectable[U]) = {
@@ -118,8 +121,11 @@ trait MatchersImplicits extends Expectations with MatchResultCombinators with Ma
   }
 
   /**
-   * The <code>SetMatcher</code> class is a matcher matching a set of objects with a matcher returned by a function.<p>
-   * Usage:<code>List(1, 2, 3) must ((beEqualTo(_:Int)).toSet)(List(2, 1, 3)) </code>
+   * The `SetMatcher` class is a matcher matching a set of objects with a matcher returned by a function.<p>
+   * Usage:
+   * {{{
+   * List(1, 2, 3) must ((beEqualTo(_:Int)).toSet)(List(2, 1, 3))
+   * }}}
    */
   class SetMatcher[S, T](s: Set[S], f: S => Matcher[T]) extends Matcher[Set[T]] {
     def apply[U <: Set[T]](t: Expectable[U]) = {

--- a/src/main/scala/org/specs2/matcher/ScalaCheckMatchers.scala
+++ b/src/main/scala/org/specs2/matcher/ScalaCheckMatchers.scala
@@ -123,7 +123,7 @@ trait ScalaCheckMatchers extends ConsoleOutput with ScalaCheckParameters
 
   /**
    * checks if the property is true for each generated value, and with the specified
-   * generation parameters <code>p</code>. <code>p</code> is transformed into a scalacheck parameters
+   * generation parameters `p`. `p` is transformed into a scalacheck parameters
    */
   private[specs2] def checkProperty(prop: Prop)(implicit p: Parameters): execute.Result = {
     checkScalaCheckProperty(prop)(p.toScalaCheckParameters(defaultPrettyParams))
@@ -310,7 +310,7 @@ trait ApplicableArbitraries { this: ScalaCheckMatchers =>
 
 }
 /**
- * This trait provides generation parameters to use with the <code>ScalaCheckMatchers</code>
+ * This trait provides generation parameters to use with the `ScalaCheckMatchers`
  */
 trait ScalaCheckParameters { outer: ScalaCheckMatchers with Output =>
   /**

--- a/src/main/scala/org/specs2/matcher/TraversableMatchers.scala
+++ b/src/main/scala/org/specs2/matcher/TraversableMatchers.scala
@@ -57,7 +57,7 @@ trait TraversableBaseMatchers extends LazyParameters { outer =>
   }
 
   /**
-   * Matches if there is one element in the traversable verifying the <code>function</code> parameter: <code>(traversable.exists(function(_))</code>
+   * Matches if there is one element in the traversable verifying the `function` parameter: `(traversable.exists(function(_))`
    */
   def have[T](function: T => Boolean) = new Matcher[GenTraversableOnce[T]]{
     def apply[S <: GenTraversableOnce[T]](traversable: Expectable[S]) = {
@@ -77,7 +77,7 @@ trait TraversableBaseMatchers extends LazyParameters { outer =>
   def allElementsLike[T, S](like: PartialFunction[T, MatchResult[S]]) = haveAllElementsLike(like)
 
   /**
-   * Matches if there l contains the same elements as the Traversable <code>traversable</code>.<br>
+   * Matches if there l contains the same elements as the Traversable `traversable`.<br>
    * This verification does not consider the order of the elements but checks the traversables recursively
    */
   def haveTheSameElementsAs[T](l: =>Traversable[T], equality: (T, T) => Boolean = (_:T) == (_:T)) =

--- a/src/main/scala/org/specs2/matcher/XmlMatchers.scala
+++ b/src/main/scala/org/specs2/matcher/XmlMatchers.scala
@@ -22,44 +22,44 @@ private[specs2]
 trait XmlBaseMatchers { outer =>
   
   /** 
-   * match if <code>node</code> is contained anywhere inside the tested node
+   * match if `node` is contained anywhere inside the tested node
    * an exact match on is required on attributes 
    */   
   def \\(node: Node, attributes: String*): XmlMatcher = deepMatch(node, attributes.toList)
-  /** match if <code>node</code> is contained anywhere inside the tested node */   
+  /** match if `node` is contained anywhere inside the tested node */
   def \\(node: Node): XmlMatcher = deepMatch(node, Nil) 
-  /** alias for <code>\\(node)</code> with the node label only */
+  /** alias for `\\(node)` with the node label only */
   def \\(label: String, attributes: String*) = deepMatch(label, attributes.toList)
   /**
-   * match if <code>node</code> is contained anywhere inside the tested node and has exactly the <code>attributeValues</code> 
+   * match if `node` is contained anywhere inside the tested node and has exactly the `attributeValues`
    * as names and values for its attributes
    */   
   def \\(node: Node, attributeValues1: (String, String), attributeValues: (String, String)*) = 
     deepMatch(node, Map((attributeValues1 :: attributeValues.toList): _*))
-  /** alias for <code>\\(node, attributeValues)</code> with the node label only */
+  /** alias for `\\(node, attributeValues)` with the node label only */
   def \\(label: String, attributeValues1: (String, String), attributeValues: (String, String)*) =
     deepMatch(label, Map((attributeValues1 :: attributeValues.toList): _*))
 
   /** 
-   * match if <code>node</code> is the first node of the tested node
+   * match if `node` is the first node of the tested node
    * an exact match on is required on attributes 
    */   
   def \(node: Node, attributes: String*): XmlMatcher = firstMatch(node, attributes.toList)
-  /** match if <code>node</code> is the first node of the tested node */   
+  /** match if `node` is the first node of the tested node */
   def \(node: Node): XmlMatcher = firstMatch(node, Nil) 
-  /** alias for <code>\(node)</code> with the node label only */
+  /** alias for `\(node)` with the node label only */
   def \(label: String, attributes: String*) = firstMatch(label, attributes.toList)
   /**
-   * match if <code>node</code> is the first node of the tested node and has exactly the <code>attributeValues</code> 
+   * match if `node` is the first node of the tested node and has exactly the `attributeValues`
    * as names and values for its attributes
    */   
   def \(node: Node, attributeValues1: (String, String), attributeValues: (String, String)*) = 
     firstMatch(node, Map((attributeValues1 :: attributeValues.toList): _*))
-  /** alias for <code>\\(node, attributeValues)</code> with the node label only */
+  /** alias for `\\(node, attributeValues)` with the node label only */
   def \(label: String, attributeValues1: (String, String), attributeValues: (String, String)*) = 
     firstMatch(label, Map((attributeValues1 :: attributeValues.toList): _*))
 
-  /** match if <code>node</code> is equal to the tested node without testing empty text */   
+  /** match if `node` is equal to the tested node without testing empty text */
   def beEqualToIgnoringSpace(node: Seq[Node]) = new EqualIgnoringSpaceMatcher(node)
   /** alias for beEqualToIgnoringSpace */
   def be_==/(node: Seq[Node]): EqualIgnoringSpaceMatcher = beEqualToIgnoringSpace(node)
@@ -151,7 +151,7 @@ case class XmlMatcher(functions: Seq[PathFunction]) extends Matcher[Seq[Node]] {
   /** do an exact match on attributes and attributes values */
   def exactly = XmlMatcher(functions.map(_.exactly))
   /**
-   * checks that the <code>nodes</code> satisfy the <code>functions</code>
+   * checks that the `nodes` satisfy the `functions`
    */
   def apply[S <: Seq[Node]](n: Expectable[S]) = {
     val nodes = n
@@ -191,7 +191,7 @@ case class XmlMatcher(functions: Seq[PathFunction]) extends Matcher[Seq[Node]] {
   /** alias for textMatches */
   def \>~(t: String) = textMatches(t)
   /**
-   * checks that the <code>nodes</code> satisfy the <code>functions</code>
+   * checks that the `nodes` satisfy the `functions`
    * @return a MatcherResult
    */
   def checkFunctions(pathFunctions: Seq[PathFunction], nodes: Seq[Node], messages: (Boolean, String, String)): (Boolean, String, String) = {
@@ -234,7 +234,7 @@ trait XPathFunctions {
 
 /**
  * The PathFunction object encapsulate a search for a node and/or attributes or attributeValues with an XPath function
- * If <code>node</code> has some children, then they are searched using equality
+ * If `node` has some children, then they are searched using equality
  */
 case class PathFunction(val node: Node,
                         val function: XPathFunction,

--- a/src/main/scala/org/specs2/mock/mockito/CalledMatchers.scala
+++ b/src/main/scala/org/specs2/mock/mockito/CalledMatchers.scala
@@ -11,8 +11,8 @@ import execute.{ResultLogicalCombinators, AsResult, Result}
 import ResultLogicalCombinators._
 
 /**
- * This trait provides methods to declare expectations on mock calls:<code>
- * 
+ * This trait provides methods to declare expectations on mock calls:
+ * {{{
  * there was one(mockedList).get(0)
  * there was no(mockedList).get(0)
  * 
@@ -33,8 +33,7 @@ import ResultLogicalCombinators._
  * 
  * there were two(mockedList).get(0)
  * got { two(mockedList).get(0) }
- * 
- * </code>
+ * }}}
  */
 trait CalledMatchers extends NumberOfTimes with FunctionArguments with TheMockitoMocker with Expectations {
   /** this matcher evaluates an expression containing mockito calls verification */

--- a/src/main/scala/org/specs2/mock/mockito/MockitoStubs.scala
+++ b/src/main/scala/org/specs2/mock/mockito/MockitoStubs.scala
@@ -9,20 +9,19 @@ import org.mockito.stubbing.{ OngoingStubbing, Stubber }
 /**
  * This trait provides functionalities to declare stub values on method calls.
  * 
- * Usage:<code>
- * 
+ * Usage:
+ * {{{
  * mockedList.get(0) returns "one"
  * mockedList.get(0) returns ("one", "two")
  * mockedList.get(0) throws new Exception("unexpected")
  * mockedList.get(0) answers ( i => "value " + i.toString )
+ * }}}
  * 
- * </code>
- * 
- * It is also possible to chain stubs like this: <code>
- * 
+ * It is also possible to chain stubs like this:
+ * {{{
  * mockedList.get(0) returns "one" thenReturns "two"
  * mockedList.get(0) returns "one" thenThrows new Exception("unexpected now")
- * </code>
+ * }}}
  */
 trait MockitoStubs extends MocksCreation with MockitoStubsLowerImplicits {
   /** delegate to MockitoMocker doAnswer with a MockAnswer object using the function f. */

--- a/src/main/scala/org/specs2/mock/mockito/MocksCreation.scala
+++ b/src/main/scala/org/specs2/mock/mockito/MocksCreation.scala
@@ -83,12 +83,12 @@ trait MocksCreation extends TheMockitoMocker with ClassesOf {
    * create a spy on an object. 
    * 
    * A spy is a real object but can still have some of its methods stubbed. However the syntax for stubbing a spy is a bit different than 
-   * with a mock:<code>
-   * 
+   * with a mock:
+   * {{{
    * val s = spy(new LinkedList[String])
    * doReturn("one").when(s).get(0) // instead of s.get(0) returns "one" which would throw an exception
    * 
-   * </code>
+   * }}}
    */
   def spy[T](m: T): T = mocker.spy(m)
   /**

--- a/src/main/scala/org/specs2/mock/mockito/NumberOfTimes.scala
+++ b/src/main/scala/org/specs2/mock/mockito/NumberOfTimes.scala
@@ -6,7 +6,7 @@ package mockito
 trait NumberOfTimes {
   /** 
    * This implicit definition allows to declare a number of times
-   * <code>3.times</code>
+   * `3.times`
    */
   implicit def integerToRange(n: Int): RangeInt = new RangeInt(n)
   case class RangeInt(n: Int) { 

--- a/src/main/scala/org/specs2/reporter/JUnitReporter.scala
+++ b/src/main/scala/org/specs2/reporter/JUnitReporter.scala
@@ -132,7 +132,7 @@ class JUnitDescriptionsFragments(className: String) extends JUnitDescriptions[Fr
     }
 }
 /**
- * This class refines the <code>AssertionFailedError</code> from junit
+ * This class refines the `AssertionFailedError` from junit
  * and provides the stackTrace of an exception which occurred during the specification execution
  */
 class SpecFailureAssertionFailedError(e: Exception) extends AssertionFailedError(e.getMessage) {

--- a/src/main/scala/org/specs2/runner/SpecificationsFinder.scala
+++ b/src/main/scala/org/specs2/runner/SpecificationsFinder.scala
@@ -62,7 +62,7 @@ trait SpecificationsFinder extends FileSystem with Classes with ConsoleOutput wi
   def specPattern(specType: String, pattern: String) = "\\s*"+specType+"\\s*(" + pattern + ")\\s*extends\\s*.*"
 
   /**
-   * @return a <code>SpecificationStructure</code> object from a className if that class is a <code>SpecificationStructure</code> class.<br>
+   * @return a `SpecificationStructure` object from a className if that class is a `SpecificationStructure` class.<br>
    * Tries to load the class name and cast it to a specification
    *         None in case of an exception.
    */
@@ -80,7 +80,7 @@ trait SpecificationsFinder extends FileSystem with Classes with ConsoleOutput wi
   }
 
   /**
-   * @return a <code>SpecificationStructure</code> object from a className if that class is a <code>SpecificationStructure</code> class.<br>
+   * @return a `SpecificationStructure` object from a className if that class is a `SpecificationStructure` class.<br>
    * Tries to load the class name and cast it to a specification
    *         None in case of an exception.
    */

--- a/src/main/scala/org/specs2/specification/RegexSteps.scala
+++ b/src/main/scala/org/specs2/specification/RegexSteps.scala
@@ -15,18 +15,18 @@ import matcher.MatchResult
  * It is used to implement a Given-When-Then way of describing systems.
  *
  * Fragments are created by adding a `Given` step to a `Text`:
- *
- *  <code>"name: ${user}" ^ givenName</code>
- *
+ * {{{
+ *  "name: ${user}" ^ givenName
+ * }}}
  * This creates a PreStep object containing the current context (representing all the extracted values) and a list of
  * Fragments containing:
  *
- *  - the Text fragment: <code>Text("name: ${user}")</code>
- *  - a Step containing the extraction code to get the value delimited by <code>${}</code>
+ *  - the Text fragment: `Text("name: ${user}")`
+ *  - a Step containing the extraction code to get the value delimited by `${}`
  *
  * Then, this PreStep object can be followed by another piece of Text to create a PreStepText object. This object merely
  * stores the additional Text fragment so that values can be extracted from it when a `When` step is added:
- * <code>
+ * {{{
  *  // this creates a PreStepText object
  *  "name: ${user}" ^ givenName ^
  *  "age: ${38}"
@@ -34,7 +34,7 @@ import matcher.MatchResult
  *  // this creates a PreStep object
  *  "name: ${user}" ^ givenName ^
  *  "age: ${38}"    ^ thenAge ^
- * </code>
+ * }}}
  *
  * Eventually, when a `Then` step is added, a sequence of PostStep/PostStepText objects is created. Those objects use
  * the current context and the results returned by the `Then` objects to create Examples.


### PR DESCRIPTION
https://wiki.scala-lang.org/display/SW/Syntax says:

> HTML element tags are not recommended in Scaladoc
### befor:

![befor](https://f.cloud.github.com/assets/389787/30302/e8eb74de-4e5f-11e2-9cae-2318a27ce4ac.png)
### after:

![after](https://f.cloud.github.com/assets/389787/30304/f61120dc-4e5f-11e2-870b-50efdb2434f6.png)
