### PR TITLE
better failure message OptionMatcher#which

### DIFF
--- a/src/test/scala/org/specs2/matcher/OptionMatchersSpec.scala
+++ b/src/test/scala/org/specs2/matcher/OptionMatchersSpec.scala
@@ -9,6 +9,9 @@ class OptionMatchersSpec extends Specification with ResultMatchers { def is = s2
   ${ Some(1) must beSome }
   ${ Some(1) must beSome(1) }
   ${ Some(1) must beSome.which(_ > 0) }
+  ${ ((None: Option[Int]) must beSome.which(_ > 0)) returns "'None' is not Some[T]" }
+  ${ (Some(1) must beSome.which(_ > 0)) returns "'Some(1)' is Some[T] and satisfies the given predicate" }
+  ${ (Some(1) must beSome.which(_ < 0)) returns "'Some(1)' is Some[T] but 1 does not satisfies the given predicate" }
   ${ Some(1) must beSome.like { case a if a > 0 => ok } }
   ${ (Some(1) must not(beSome.like { case a => a must be_>=(0) })) returns "'Some(1)' is Some[T] and 1 is not less than 0" }
   ${ Some(1) must not be some(2) }


### PR DESCRIPTION
old implementation
`Some(1) must beSome.which(_ < 0)` returns `'None' is not Some[T]`

when you find a mistake in my English in this pull request code, will you please point it out and correct it?
because I am not a native English speaker.
