### PR TITLE
Update plugins.sbt

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.6.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.1")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.5.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.1")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.7.1")


### PR DESCRIPTION
The sbt-git plugin version 0.5.1 does not exist (there has never been a release with this version number). There is however a sbt-git version 0.6.1 (sbt-ghpages has a release v0.5.1, maybe that was the source of the confusion). (cc @jsuereth).
