### PR TITLE
Improved support for Hamcrest matchers

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -22,7 +22,7 @@ object dependencies {
   def specs2 = Seq(
       "org.scalacheck"          %% "scalacheck"        % "1.10.0"      % "optional",
       "com.chuusai"             %% "shapeless"         % "1.2.4"       % "optional",
-      "org.hamcrest"            % "hamcrest-all"       % "1.1"         % "optional",
+      "org.hamcrest"            % "hamcrest-core"      % "1.2"         % "optional",
       "org.mockito"             % "mockito-all"        % "1.9.0"       % "optional",
       "junit"                   % "junit"              % "4.11"        % "optional",
       "org.pegdown"             % "pegdown"            % "1.2.1"       % "optional",

--- a/src/main/scala/org/specs2/matcher/Hamcrest.scala
+++ b/src/main/scala/org/specs2/matcher/Hamcrest.scala
@@ -19,8 +19,11 @@ trait Hamcrest {
   def createKoMessageFromHamcrest[T](t: =>T, hamcrest: org.hamcrest.Matcher[T]): String = {
     val description = new StringDescription
 
-    description.appendValue(t)
-    hamcrest.describeTo(description)
+    description
+       .appendText("\nExpected: ")
+       .appendDescriptionOf(hamcrest)
+       .appendText("\n     but: ")
+    hamcrest.describeMismatch(t, description)
     description.toString
   }
 

--- a/src/test/scala/org/specs2/matcher/HamcrestSpec.scala
+++ b/src/test/scala/org/specs2/matcher/HamcrestSpec.scala
@@ -13,13 +13,16 @@ class HamcrestSpec extends script.Specification with Grouped with Hamcrest { def
 
   new g1 {
     e1 := 2 must beEven
-    e2 := (3 must beEven).message === "<3> is odd"
+    e2 := (3 must beEven).message === "\nExpected: an even Int\n     but: <3> is odd"
   }
 
   // a Hamcrest matcher for even numbers
   object beEven extends BaseMatcher[Int] {
-    def matches(item: Object): Boolean       = item.toString.toInt % 2 == 0
-    def describeTo(description: Description) { description.appendText(" is odd") }
+    def matches(item: Object): Boolean = item.toString.toInt % 2 == 0
+    def describeTo(description: Description): Unit = { description.appendText("an even Int") }
+    override def describeMismatch(item: Object, description: Description): Unit = {
+      description.appendValue(item).appendText(" is odd")
+    }
   }
 
 }


### PR DESCRIPTION
The Hamcrest implicit incorrectly treats the matcher.describeTo method as the failure (mismatch) description. It really is the description of what is expected. In addition, Hamcrest 1.2 introduced a new method on the Matcher interface, describeMismatch, which allows Matchers to provide specific details on why the actual value does not match the expected value.

I've updated the implicit to generate a message more consistent with what Hamcrest users expect that takes advantage of the describeMismatch method.

Moving to Hamcrest 1.2 shouldn't be a problem because most Hamcrest users have moved on to 1.2 or higher.
