### PR TITLE
Proposing a fix for HTML resource copying

### DIFF
--- a/html/src/main/scala/org/specs2/reporter/HtmlFileWriter.scala
+++ b/html/src/main/scala/org/specs2/reporter/HtmlFileWriter.scala
@@ -34,6 +34,6 @@ trait HtmlFileWriter extends OutputDir {
 
    /** copy css and images file to the output directory */
   protected def copyResources() {
-    Seq("css", "images", "css/themes/default").foreach(fileSystem.copySpecResourcesDir(_, outputDir))
+    Seq("css", "images", "css/themes/default").foreach(fileSystem.copySpecResourcesDir(_, outputDir, classOf[HtmlFileWriter].getClassLoader))
   }
 }

--- a/html/src/test/scala/org/specs2/reporter/HtmlFileWriterSpec.scala
+++ b/html/src/test/scala/org/specs2/reporter/HtmlFileWriterSpec.scala
@@ -10,19 +10,22 @@ class HtmlFileWriterSpec extends Specification with Mockito { outer => def is = 
 The HtmlFileWriter class is responsible for writing a html reports to disk.
                                                                                      
   Resources                                                                                                           
-    there must be a directory for css files                                                     ${resources().css}
-    there must be a directory for images files                                                  ${resources().images}
-    there must be a directory for the js tree theme files                                       ${resources().jstheme}
-                                                                                                                        """
+    there must be a directory for css files                        ${resources().css}
+    there must be a directory for images files                     ${resources().images}
+    there must be a directory for the js tree theme files          ${resources().jstheme}
+
+    the css files must be in the classpath                         ${loading().css}
+    the images files must be in the classpath                      ${loading().images}
+    the js tree theme files must be in the classpath               ${loading().jstheme}                                                                                                                    """
                                                                                           
   implicit val arguments = args()
 
   case class resources() extends MockHtmlFileWriter {
     writer.writeFiles(arguments)(Seq())
-    
-    def css = there was one(fs).copySpecResourcesDir(===("css"), anyString)
-    def images = there was one(fs).copySpecResourcesDir(===("images"), anyString)
-    def jstheme = there was one(fs).copySpecResourcesDir(===("css/themes/default"), anyString)
+
+    def css = there was one(fs).copySpecResourcesDir(===("css"), anyString, any[ClassLoader])
+    def images = there was one(fs).copySpecResourcesDir(===("images"), anyString, any[ClassLoader])
+    def jstheme = there was one(fs).copySpecResourcesDir(===("css/themes/default"), anyString, any[ClassLoader])
   }
 
   trait MockHtmlFileWriter extends FragmentExecution with DefaultStoring { outer =>
@@ -33,7 +36,13 @@ The HtmlFileWriter class is responsible for writing a html reports to disk.
       override lazy val fileSystem = fs
       override lazy val fileWriter = outer.fileWriter
     }
-
   }
 
+  case class loading() {
+    def css = load("css") should not beNull
+    def images = load("images") should not beNull
+    def jstheme = load("css/themes/default") should not beNull
+
+    private def load(name: String) = classOf[HtmlFileWriter].getClassLoader.getResource(name)
+  }
 }

--- a/project/build.scala
+++ b/project/build.scala
@@ -64,9 +64,11 @@ object build extends Build {
       publicationSettings
 
   lazy val rootSettings: Seq[Settings] = Seq(
-      sources in Compile  := sources.all(aggregateCompile).value.flatten,
-      sources in Test     := sources.all(aggregateTest).value.flatten,
-      libraryDependencies := libraryDependencies.all(aggregateTest).value.flatten
+      sources in Compile                      := sources.all(aggregateCompile).value.flatten,
+      unmanagedResourceDirectories in Compile := unmanagedResourceDirectories.all(aggregateCompile).value.flatten,
+      sources in Test                         := sources.all(aggregateTest).value.flatten,
+      unmanagedResourceDirectories in Test    := unmanagedResourceDirectories.all(aggregateTest).value.flatten,
+      libraryDependencies                     := libraryDependencies.all(aggregateTest).value.flatten
     )
 
   /** MODULES (sorted in alphabetical order) */


### PR DESCRIPTION
Hi Eric,

in the current specs2 version (2.3), the CSS and Javascript resources are not copied properly to the HTML output directory. The cause is twofold:

1) In case of the single JAR publication, the single JAR does not even contain the resources. I fixed this in the SBT build.

2) In case of the multiple JAR publication, the issue was (most unsurprisingly) class loading. The class used to locate the JAR (an anonymous inner class of org.specs2.reporter.OutputDir) is located in a different JAR (in specs2-core) than the HTML resources (which are in specs2-html). 

Therefore (in both cases) the copying (silently) did nothing.

I also added a (probably not too useful) test.

Hope this helps.

Kind regards
Andreas

P.S. I'm not sure why you used the thread context class loader. Was this because of a bug in the past and/or something I overlooked?

P.P.S. I took the liberty to wrap some file handling in try/finally to avoid resource leaks.
