### PR TITLE
Decision Table implicit conversion

### DIFF
--- a/form/src/main/scala/org/specs2/specification/FormSpecificationStringContext.scala
+++ b/form/src/main/scala/org/specs2/specification/FormSpecificationStringContext.scala
@@ -11,8 +11,6 @@ trait FormSpecificationStringContext extends SpecificationStringContext { this: 
   implicit def formIsSpecPart(f: =>Form): SpecPart = new SpecPart {
     def append(fs: Fragments, text: String, expression: String = "") = fs.append(createTextFragment(text)).append(formsAreExamples(f.executeForm))
   }
-  implicit def toFormIsSpecPart(f: { def form: Form}): SpecPart = new SpecPart {
-    def append(fs: Fragments, text: String, expression: String = "") = fs append { formIsSpecPart(f.form).append(text, expression) }
-  }
+  implicit def toFormIsSpecPart(f: { def form: Form}): SpecPart = formIsSpecPart(f.form)
 }
 


### PR DESCRIPTION
Hi Eric,

I noticed that in the following spec using a decision table, the name of the example method appears in the output  when the decision table is converted to a spec part implicitly. It doesn't when I explicitly invoke ".form" on the table.

``` scala
package meep

import org.specs2._
import org.specs2.form._
import org.specs2.specification._

class MeepSpec extends Specification with Forms { def is =
s2"""
The road runner should run and meep. $thisWordShouldNotAppear
"""

  def thisWordShouldNotAppear =
    Meeper.
      th("movement", "sound", "movement & sound").
      tr("running", "meep", "running & meep").
      tr("waling", "toot", "walking & toot")   // if I add .form after this, it works fine

  case class Meeper(form: Form = Form()) {
    def tr(movement: String, sound: String, movementAndSound: String) = Meeper {
      def both = prop(movement + " & " + sound)(movementAndSound)
      form.tr(movement, sound, both)
    }
  }
  object Meeper {
    def th(title1: String, titles: String*) = Meeper(Form.th(title1, titles:_*))
  }
}
```

So with this pull request, I changed the implicit conversion from the table to a spec part to behave identically to the conversion from a form to a spec part. I'm not entirely sure what was/is going on, maybe an "auto example" was triggered by some kind of "example wrapped in example" kind of thing?

If this was indeed the expected behaviour, please ignore this pull request. :) But if so, you should probably document it somewhere. (The user guide on decision tables suffers from this behaviour, too, btw.)

Hope this helps anyway.

Kind regards
Andreas
