### PR TITLE
migrates to 2.11.0-RC1

### DIFF
--- a/matcher-extra/src/main/scala/org/specs2/matcher/MatcherMacros.scala
+++ b/matcher-extra/src/main/scala/org/specs2/matcher/MatcherMacros.scala
@@ -144,8 +144,13 @@ object MatcherMacros extends MatcherMacros {
     }
   }
 
+  // TODO 2.11 Remove this after dropping 2.10.x support.
+  private object HasCompat { val compat = ??? }; import HasCompat._
+
   /** set a specific position to the elements of a tree  */
-  private def setPosition(c: Context)(position: c.Position) = { import c.universe._
+  private def setPosition(c: Context)(position: c.Position) = {
+    import c.universe._
+    import compat._
     new Transformer {
       override def transform(tree: Tree) = tree match {
         case t => super.transform(t).setPos(position)


### PR DESCRIPTION
This pull request migrates the master branch to be compatible with the recently merged scala/scala#3452 without losing cross-compilation for 2.10.x.
