### PR TITLE
migrates to paradise 2.0.0-M6

### DIFF
--- a/matcher-extra/src/main/scala/org/specs2/matcher/MatcherMacros.scala
+++ b/matcher-extra/src/main/scala/org/specs2/matcher/MatcherMacros.scala
@@ -3,7 +3,6 @@ package matcher
 
 import scala.reflect.macros.Context
 import scala.annotation.StaticAnnotation
-import scala.quasiquotes.RuntimeLiftables._
 
 /**
  * Macro definitions to generate matchers for the members of a type T
@@ -102,13 +101,9 @@ object MatcherMacros extends MatcherMacros {
 
 }
 
-import scala.quasiquotes.StandardLiftables
-
-class MakeMatchers[C <: Context](val c: C) extends StandardLiftables {
+class MakeMatchers[C <: Context](val c: C) {
 
   import c.universe._
-
-  val u: c.universe.type = c.universe
 
   def matchers[T: c.WeakTypeTag] = {
     val typeOfT = weakTypeOf[T]

--- a/project/build.scala
+++ b/project/build.scala
@@ -46,7 +46,7 @@ object build extends Build {
 
   lazy val specs2Version = settingKey[String]("defines the current specs2 version")
   lazy val scalazVersion = settingKey[String]("defines the current scalaz version")
-  lazy val paradisePlugin = compilerPlugin("org.scalamacros" %% "paradise" % "2.0.0-M5" cross CrossVersion.full)
+  lazy val paradisePlugin = compilerPlugin("org.scalamacros" %% "paradise" % "2.0.0-M6" cross CrossVersion.full)
 
   lazy val aggregateCompile = ScopeFilter(
              inProjects(common, matcher, matcherExtra, core, html, analysis, form, markdown, gwt, junit, scalacheck, mock),
@@ -155,7 +155,7 @@ object build extends Build {
     settings = moduleSettings ++ Seq(
       libraryDependencies ++= (if (scalaVersion.value.startsWith("2.11")) Nil else 
         List(paradisePlugin,
-             "org.scalamacros" %% "quasiquotes" % "2.0.0-M5" cross CrossVersion.full))
+             "org.scalamacros" %% "quasiquotes" % "2.0.0-M6" cross CrossVersion.full))
     )
   ).dependsOn(analysis, scalacheck, matcher, core % "test->test")
 


### PR DESCRIPTION
This should remove the source incompatibility with 2.11 introduced by recent migration to M4/M5, making specs2 eligible for dbuilding again: https://github.com/typesafehub/community-builds/pull/30.

Checked the 2.10.3 build for `specs2-matcher-extra` locally, and it passed. Not sure how to check the 2.11 build, because just running with `++2.11.0-RC3` didn't get me far.
