### PR TITLE
Improved exception matchers to have stacktrace in case of failure

### DIFF
--- a/matcher/src/main/scala/org/specs2/matcher/ExceptionMatchers.scala
+++ b/matcher/src/main/scala/org/specs2/matcher/ExceptionMatchers.scala
@@ -5,6 +5,7 @@ import control.Exceptions._
 import scala.reflect.ClassTag
 import text.NotNullStrings._
 
+
 /**
  * These matchers can be used to check if exceptions are thrown or not
  */
@@ -97,7 +98,7 @@ trait ExceptionBaseMatchers extends Expectations {
       exception.getClass == e.getClass && exception.getMessage.notNull == e.getMessage.notNull
     }
 
-    private def checkBoolean[T](expectable: Expectable[T], f: Throwable => Boolean) = {
+	    private def checkBoolean[T](expectable: Expectable[T], f: Throwable => Boolean) = {
       checkExceptionValue(expectable, f, exception.toString)
     }
     private def checkMatchResult[T](expectable: Expectable[T], e: Throwable => Boolean, f: PartialFunction[E, MatchResult[Any]]) = {
@@ -108,7 +109,7 @@ trait ExceptionBaseMatchers extends Expectations {
     checkException(expectable, 
                    f,
                    (e: Throwable) => "Got the exception " + e,
-                   (e: Throwable) => "Expected: "+ expectedAsString + ". Got: " + e + " instead",
+                   (e: Throwable) => "Expected: "+ expectedAsString + ". Got: " + e + " instead with stack trace " + e.getStackTrace.mkString("\r\n"),
                    "Got the exception " + expectedAsString,
                     "Expected: "+ expectedAsString + ". Got nothing")
   }
@@ -116,7 +117,7 @@ trait ExceptionBaseMatchers extends Expectations {
     checkExceptionWithMatcher(expectable,
                    e, f,
                    (e: Throwable) => "Got the exception " + e,
-                   (e: Throwable) => "Expected: "+ expectedAsString + ". Got: " + e + " instead",
+                   (e: Throwable) => "Expected: "+ expectedAsString + ". Got: " + e + " instead with stacktrace: " + e.getStackTrace.mkString("\r\n"),
                    "Got the exception " + expectedAsString,
                     "Expected: "+ expectedAsString + ". Got nothing")
   }


### PR DESCRIPTION
As from ML discussion, the case is simple:

``` scala
class FailingSpec extends Specification{

    def is = s2""""
                                    This is cool $e1      """

    def e1 =
        foreach( 1 to 10 ){
            index =>foreach (index to index * 3) {
                subIndex => subIndex must explodeBooh or throwA[NullPointerException]
            }
    }

    def explodeBooh = new Matcher[Int]{
        override def apply[S <: Int](t: Expectable[S]): MatchResult[S] = {
            val value = t.value
            if(value%2==0)
                explodingMethod
            else
                result(true,"It works","It doesn't work",t)
        }
    }

    def explodingMethod[S]:MatchResult[S] = {
        subExplodingMethod

    }

    def subExplodingMethod[S]:MatchResult[S] = {
        throw new IllegalArgumentException("baah")
    }
}
```
