### PR TITLE
Some exceptions do not contain a message

### DIFF
--- a/common/src/main/scala/org/specs2/reflect/Classes.scala
+++ b/common/src/main/scala/org/specs2/reflect/Classes.scala
@@ -100,7 +100,12 @@ trait Classes extends Output {
               case Some(r) => r
               case None    =>
                 val exception = results.collect { case Left(e) => e }.iterator.toSeq.headOption.getOrElse(new Exception("no cause"))
-                Left(new Exception("Could not instantiate class "+c.getName+": "+exception.getMessage.mkString(", "), exception))
+                val message = if (exception.getMessage == null) {
+                  "Could not instantiate class " + c.getName
+                } else {
+                  "Could not instantiate class " + c.getName + ": " + exception.getMessage.mkString(", ")
+                }
+                Left(new Exception(message, exception))
             }
           }
         } catch {


### PR DESCRIPTION
E.g. InvocationTargetException thrown when a class cannot be instantiated
does not contain a message, resulting in a NPE exception in specs,
making the stacktrace useless.

java.lang.Exception: Could not instantiate class XSpec: null

for the test

import org.specs2.mutable.Specification

class XSpec extends Specification {

  val tested = new TestedComponent

  "A spec" should {
    "not fail with NPE" in {
      success
    }
  }

}

case class MyException(message: String) extends
RuntimeException(message)

class TestedComponent {

  val value = {
    // This causes a InvocationTargetException with a null message,
    // resulting in the stack trace from specs:
    // java.lang.Exception: Could not instantiate class XSpec: null
    if (1 == 1) throw new MyException("Oops")
    "Oops"
  }
}
