### PR TITLE
Exception matchers should work for failed futures with await

### DIFF
--- a/tests/src/test/scala/org/specs2/matcher/FutureMatchersSpec.scala
+++ b/tests/src/test/scala/org/specs2/matcher/FutureMatchersSpec.scala
@@ -21,6 +21,9 @@ class FutureMatchersSpec extends Specification with Groups with NoTimeConversion
  A `Future` returning a `Matcher[T]` can be transformed into a `Result`
  ${ Future(1 === 1).await }
 
+ A `throwA[T]` matcher can be used to match a failed future with the `await` method
+ ${ Future.failed(new RuntimeException) must throwA[RuntimeException].await }
+
 """
 
   // the current execution context can be overridden here


### PR DESCRIPTION
This commit just adds a failing test.

I was having trouble figuring out what would actually need to happen to make this work, but I figured a failing test might at least be helpful.
