### PR TITLE
Fix typo in Context.scala

### DIFF
--- a/core/src/main/scala/org/specs2/specification/Context.scala
+++ b/core/src/main/scala/org/specs2/specification/Context.scala
@@ -30,7 +30,7 @@ trait BeforeAfter extends Before with After { outer =>
 }
 
 /**
- * The BeforeAfter trait allows to declare before, around and after actions
+ * The BeforeAfterAround trait allows to declare before, around and after actions
  * 
  * @see Before
  * @see After


### PR DESCRIPTION
Fix incorrect trait name in doc-string for BeforeAfterAround trait.
