### PR TITLE
Passing all method's arguments to mock's callback function

### DIFF
--- a/mock/src/main/scala/org/specs2/mock/mockito/MockitoStubs.scala
+++ b/mock/src/main/scala/org/specs2/mock/mockito/MockitoStubs.scala
@@ -89,7 +89,8 @@ trait MockitoStubs extends MocksCreation with MockitoStubsLowerImplicits {
                              case f: Function0[_]   => f().asInstanceOf[T]
                              case f: Function1[_,_] => f(invocation.getMock).asInstanceOf[T]
                            }
-       else                function(args(0)).asInstanceOf[T]
+       else if(args.size == 1) function(args(0)).asInstanceOf[T]
+       else function(args).asInstanceOf[T]
      }
   }
 

--- a/mock/src/test/scala/org/specs2/mock/MockitoSpec.scala
+++ b/mock/src/test/scala/org/specs2/mock/MockitoSpec.scala
@@ -112,6 +112,7 @@ STUBS
  ============================
 
  + Answers can be created to control the returned a value
+ + Answers can use the method's parameters passed as an array
  + Answers can use the mock instance as the second parameter
  + Answers can use the mock instance, even when the method has 0 parameters
 
@@ -410,10 +411,17 @@ STUBS
       list.get(anyInt) answers { i => "The parameter is " + i.toString }
       list.get(2) must_== "The parameter is 2"
     }
+
+    eg := {
+      list.set(anyInt, anyString) answers { i => "The parameters are " + (i.asInstanceOf[Array[_]].mkString("(",",",")")) }
+      list.set(1,"foo") must_== "The parameters are (1,foo)"
+    }
+
     eg := {
       list.get(anyInt) answers { (i, m) => "The parameters are " + (i.asInstanceOf[Array[_]].mkString -> m) }
       list.get(1) must_== "The parameters are (1,list)"
     }
+
     eg := {
       list.size answers { m => m.toString.size }
       list.size must_== 4


### PR DESCRIPTION
The previous version passed only the first argument of the mocked method to the callback function. This was only the case for single argument callbacks, the version with two arguments worked fine.
