### PR TITLE
Upgrade to scalacheck 1.12.0

### DIFF
--- a/core/src/test/scala/org/specs2/collection/SeqxSpec.scala
+++ b/core/src/test/scala/org/specs2/collection/SeqxSpec.scala
@@ -64,7 +64,6 @@ trait ScalaCheckResult {
         case `Passed` | Proved(_)           => Success()
         case Failed(args, labels)           => Failure("Property failed with args: "+args.mkString(", ")+" and labels "+labels.mkString(", "))
         case PropException(args, e, labels) => Error(e).updateMessage("Property failed with args: "+args.mkString(", ")+" and labels "+labels.mkString(", "))
-        case GenException(e)                => Error(e)
         case `Exhausted`                    => Error("exhausted")
       }
     }

--- a/project/build.scala
+++ b/project/build.scala
@@ -219,7 +219,7 @@ object build extends Build {
   /**
    * Main libraries 
    */
-  lazy val scalacheckLib = "org.scalacheck" %% "scalacheck"   % "1.11.3"
+  lazy val scalacheckLib = "org.scalacheck" %% "scalacheck"   % "1.12.0"
   lazy val mockitoLib    = "org.mockito"    % "mockito-core"  % "1.9.5"
   lazy val junitLib      = "junit"          % "junit"         % "4.11"
   lazy val hamcrestLib   = "org.hamcrest"   % "hamcrest-core" % "1.3"

--- a/scalacheck/src/main/scala/org/specs2/matcher/ScalaCheckMatchers.scala
+++ b/scalacheck/src/main/scala/org/specs2/matcher/ScalaCheckMatchers.scala
@@ -77,11 +77,6 @@ trait CheckProperty {
       case Result(Passed, succeeded, discarded, fq, _)     =>
         execute.Success(noCounterExample(succeeded), frequencies(fq), succeeded)
 
-      case r @ Result(GenException(execute.FailureException(f)), n, _, fq, _) => f
-
-      case r @ Result(GenException(e), n, _, fq, _)        =>
-        execute.Failure(prettyTestRes(r)(defaultPrettyParams) + frequencies(fq), e.getMessage.notNull, e.getStackTrace.toList)
-
       case r @ Result(Exhausted, n, _, fq, _)              =>
         execute.Failure(prettyTestRes(r)(defaultPrettyParams) + frequencies(fq))
 


### PR DESCRIPTION
specs2 is preventing us from upgrading to scalacheck 1.12.0 which is in turn preventing us from upgrading to scala 2.11.4. So this is my attempt at upgrading the scalacheck dependency.

The "A specification can reference itself without creating a loop" test in `FragmentsBuilderIntegrationSpec` is failing and I don't know enough about the changes to Scalacheck to fix it presently, but I'm going to seek help. In the meantime I am submitting this PR for commentary.
