### PR TITLE
Introduced responds method that allows to use anonymous case function for a mock

### DIFF
--- a/guide/src/test/scala/org/specs2/guide/UseMockito.scala
+++ b/guide/src/test/scala/org/specs2/guide/UseMockito.scala
@@ -125,6 +125,14 @@ m.get(0)    // returns "The parameter is 0"
 m.get(1)    // the second call returns a different value: "The parameter is 1"
 }}
 
+To use specific type of arguments: ${snippet{
+m.get(anyInt) answers { _ match { case i: Int => (i + 1).toString } }
+}}
+
+Or more concise: ${snippet{
+m.get(anyInt) responds { case i: Int => (i + 1).toString }
+}}
+
 #### Parameters for the `answers` function
 
 Because of the use of reflection the function passed to answers will receive only instances of the `java.lang.Object` type.

--- a/mock/src/main/scala/org/specs2/mock/mockito/MockitoStubs.scala
+++ b/mock/src/main/scala/org/specs2/mock/mockito/MockitoStubs.scala
@@ -15,6 +15,7 @@ import org.mockito.stubbing.{ OngoingStubbing, Stubber }
  * mockedList.get(0) returns ("one", "two")
  * mockedList.get(0) throws new Exception("unexpected")
  * mockedList.get(0) answers ( i => "value " + i.toString )
+ * mockedList.get(any) responds { case i: Int => (i + 1).toString }
  * }}}
  * 
  * It is also possible to chain stubs like this:
@@ -43,6 +44,7 @@ trait MockitoStubs extends MocksCreation with MockitoStubsLowerImplicits {
     }
     def answers(function: Any => T) = mocker.when(c).thenAnswer(new MockAnswer(function))
     def answers(function: (Any, Any) => T) = mocker.when(c).thenAnswer(new MockAnswer2(function))
+    def responds(function: Any => T) = answers(function)
     def throws[E <: Throwable](e: E*): OngoingStubbing[T] = {
       if (e.isEmpty) throw new java.lang.IllegalArgumentException("The parameter passed to throws must not be empty")
       e.drop(1).foldLeft(mocker.when(c).thenThrow(e.head)) { (res, cur) => res.thenThrow(cur) }

--- a/mock/src/test/scala/org/specs2/mock/MockitoSpec.scala
+++ b/mock/src/test/scala/org/specs2/mock/MockitoSpec.scala
@@ -429,6 +429,12 @@ STUBS
     }
 
     eg := {
+      list.get(anyInt) responds { case i: Int => (i + 1).toString }
+      list.get(1) must_== "2"
+      list.get(5) must_== "6"
+    }
+
+    eg := {
       list.set(anyInt, anyString) answers { i => "The parameters are " + (i.asInstanceOf[Array[_]].mkString("(",",",")")) }
       list.set(1,"foo") must_== "The parameters are (1,foo)"
     }


### PR DESCRIPTION
Cannot use anonymous case function for answers because of overloading (it requires signature specified, so it's necessary to write more code: answers { _ match { case i: Int => (i + 1).toString } }