### PR TITLE
Drop scalaz bintray repo from quickstart page.

### DIFF
--- a/guide/src/test/resources/quickstart.html
+++ b/guide/src/test/resources/quickstart.html
@@ -29,8 +29,6 @@
                     <pre><code class="prettyprint tab-code">// Read <a href="$GUIDE_DIR$/org.specs2.guide.Installation.html#other-dependencies">here</a> for optional jars and dependencies
 libraryDependencies ++= Seq("org.specs2" %% "specs2-core" % "$VERSION$" % "test")
 
-resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
-
 scalacOptions in Test ++= Seq("-Yrangepos")</code></pre>
         </li>
 


### PR DESCRIPTION
No longer needed as of 3.6.3.