### PR TITLE
Update scalaz dependency to 7.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,19 +11,19 @@
         <dependency>
             <groupId>org.scalaz</groupId>
             <artifactId>scalaz-core_2.10</artifactId>
-            <version>7.1.1</version>
+            <version>7.1.3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.scalaz</groupId>
             <artifactId>scalaz-concurrent_2.10</artifactId>
-            <version>7.1.1</version>
+            <version>7.1.3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.scalaz</groupId>
             <artifactId>scalaz-effect_2.10</artifactId>
-            <version>7.1.1</version>
+            <version>7.1.3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Addresses https://github.com/scalaz/scalaz/pull/932

Took me a couple of hours to figure out why I was getting `java.lang.reflect.MalformedParameterizedTypeException` exceptions when trying to autowire beans in my test classes. Traced it down to the above pull request which fixes the issue in Scala 2.11.x.