### PR TITLE
Only fail on a future if Await.result timeouts

### DIFF
--- a/matcher/src/main/scala/org/specs2/matcher/FutureMatchers.scala
+++ b/matcher/src/main/scala/org/specs2/matcher/FutureMatchers.scala
@@ -48,10 +48,10 @@ trait FutureBaseMatchers extends ExpectationsCreation {
       def awaitFuture(remainingRetries: Int, totalDuration: FiniteDuration): Result = {
         try Await.result(f.map(value => AsResult(value))(ee.executionContext), appliedTimeout)
         catch {
-          case e: TimeoutException =>
+          case e if e.getClass == classOf[TimeoutException] =>
             if (remainingRetries <= 0) Failure(s"Timeout after ${totalDuration + appliedTimeout} (retries = $retries, timeout = $timeout)")
             else                       awaitFuture(remainingRetries - 1, totalDuration + appliedTimeout)
-          case other: Throwable    => throw other
+          case other: Throwable                             => throw other
         }
       }
       awaitFuture(retries, 0.second)

--- a/tests/src/test/scala/org/specs2/matcher/FutureMatchersSpec.scala
+++ b/tests/src/test/scala/org/specs2/matcher/FutureMatchersSpec.scala
@@ -11,6 +11,7 @@ class FutureMatchersSpec(env: Env) extends Specification with ResultMatchers wit
  val sleepTime = 50 * timeFactor.toLong
  implicit val ee = env.executionEnv
  implicit val ec = env.executionContext
+ class MyTimeout extends TimeoutException
 
  def is = section("travis") ^ s2"""
 
@@ -28,6 +29,10 @@ class FutureMatchersSpec(env: Env) extends Specification with ResultMatchers wit
 
  with a timeout only
  ${ Future { Thread.sleep(sleepTime); 1 } must be_>(0).awaitFor(200.millis) }
+
+ timeout applies only to `TimeoutException` itself, not subclasses
+ ${ (Future { throw new TimeoutException } must throwA[TimeoutException].await) returns "Timeout" }
+ ${ Future { throw new MyTimeout } must throwA[MyTimeout].await }
 
  A `Future` returning a `Matcher[T]` can be transformed into a `Result`
  ${ Future(1 === 1).await }


### PR DESCRIPTION
This seems like an unnecessary check, but if the Future fails with some `T <: TimeoutException`, this exception would be swallowed and wrongly reported as a Failure.
I got this recently when trying to test some akka ask behavior and they fail with a [AskTimoeutException](https://github.com/akka/akka/blob/v2.3.14/akka-actor/src/main/scala/akka/pattern/AskSupport.scala#L21). Using `await`, I couldn't test that this particular Exception was failing the Future.
The proposed fix only works for actual subclasses, not if some other code fails with a `TimeoutExeption` directly.