### PR TITLE
Implements selection to run a test multiple times.

### DIFF
--- a/common/src/main/scala/org/specs2/main/Arguments.scala
+++ b/common/src/main/scala/org/specs2/main/Arguments.scala
@@ -26,6 +26,7 @@ case class Arguments (
   commandLine:   CommandLine      = CommandLine()
  ) extends ShowArgs {
   def ex: String                      = select.ex
+  def times: Int                      = select.times
   def include: String                 = select.include
   def exclude: String                 = select.exclude
   def keep(tags: String*)             = select.keep(tags:_*)

--- a/common/src/main/scala/org/specs2/main/ArgumentsArgs.scala
+++ b/common/src/main/scala/org/specs2/main/ArgumentsArgs.scala
@@ -21,6 +21,7 @@ trait ArgumentsCreation {
   /** shorthand method to create an Arguments object */
   def args(
     ex:            ArgProperty[String]            = ArgProperty[String](),
+    times:         ArgProperty[Int]               = ArgProperty[Int](),
     include:       ArgProperty[String]            = ArgProperty[String](),
     exclude:       ArgProperty[String]            = ArgProperty[String](),
     was:           ArgProperty[String]            = ArgProperty[String](),
@@ -37,6 +38,7 @@ trait ArgumentsCreation {
 
      (new ArgumentsNamespace).select(
             ex         = ex,
+            times      = times,
             include    = include,
             exclude    = exclude,
             was        = was)       <|
@@ -58,6 +60,7 @@ trait ArgumentsCreation {
     /** shorthand method to create an Arguments object */
     def select(
       ex:            ArgProperty[String]            = ArgProperty[String](),
+      times:         ArgProperty[Int]               = ArgProperty[Int](),
       include:       ArgProperty[String]            = ArgProperty[String](),
       exclude:       ArgProperty[String]            = ArgProperty[String](),
       was:           ArgProperty[String]            = ArgProperty[String](),

--- a/common/src/main/scala/org/specs2/main/Select.scala
+++ b/common/src/main/scala/org/specs2/main/Select.scala
@@ -8,6 +8,7 @@ import data.SeparatedTags
  */
 case class Select(
                    _ex:            Option[String]           = None,
+                   _times:         Option[String]           = None,
                    _include:       Option[String]           = None,
                    _exclude:       Option[String]           = None,
                    _was:           Option[String]           = None,
@@ -16,6 +17,18 @@ case class Select(
   import Arguments._
 
   def ex: String                    = _ex.getOrElse(".*")
+
+  def times: Int                    = {
+    val default: Int = 1
+
+    _times flatMap { t =>
+      scala.util.Try(t.toInt).toOption map {
+        case i if i > 0 => i
+        case _ => default  // non-positive value
+      }
+    } getOrElse default // non-numeric value, or value not provided
+  }
+
   def include: String               = _include.getOrElse("")
   def exclude: String               = _exclude.getOrElse("")
   def keep(tags: String*)           = SeparatedTags(include, exclude).keep(tags)
@@ -28,6 +41,7 @@ case class Select(
   def overrideWith(other: Select) = {
     new Select(
       other._ex              .orElse(_ex),
+      other._times           .orElse(_times),
       other._include         .orElse(_include),
       other._exclude         .orElse(_exclude),
       other._was             .orElse(_was),
@@ -37,6 +51,7 @@ case class Select(
 
   override def toString = List(
     "ex"             -> _ex         ,
+    "times"          -> _times      ,
     "include"        -> _include    ,
     "exclude"        -> _exclude    ,
     "was"            -> _was        ,
@@ -47,11 +62,12 @@ object Select extends Extract {
   def extract(implicit arguments: Seq[String], systemProperties: SystemProperties): Select = {
     new Select (
       _ex            = value("ex", ".*"+(_:String)+".*"),
+      _times         = value("times"),
       _include       = value("include"),
       _exclude       = value("exclude"),
       _was           = value("was"),
       _selector      = value("selector")
     )
   }
-  val allValueNames = Seq("ex", "include", "exclude", "was", "selector")
+  val allValueNames = Seq("ex", "times", "include", "exclude", "was", "selector")
 }

--- a/core/src/main/scala/org/specs2/specification/dsl/mutable/ArgumentsDsl.scala
+++ b/core/src/main/scala/org/specs2/specification/dsl/mutable/ArgumentsDsl.scala
@@ -24,6 +24,7 @@ trait ArgumentsCreation extends org.specs2.main.ArgumentsCreation with MutableAr
   /** shorthand method to create an Arguments object */
   override def args(
                      ex:            ArgProperty[String]            = ArgProperty[String](),
+                     times:         ArgProperty[Int]               = ArgProperty[Int](),
                      include:       ArgProperty[String]            = ArgProperty[String](),
                      exclude:       ArgProperty[String]            = ArgProperty[String](),
                      was:           ArgProperty[String]            = ArgProperty[String](),
@@ -40,6 +41,7 @@ trait ArgumentsCreation extends org.specs2.main.ArgumentsCreation with MutableAr
 
     updateArguments(super.args(
       ex,
+      times,
       include,
       exclude,
       was,
@@ -59,11 +61,13 @@ trait ArgumentsCreation extends org.specs2.main.ArgumentsCreation with MutableAr
     /** shorthand method to create an Arguments object */
     override def select(
                          ex:            ArgProperty[String]            = ArgProperty[String](),
+                         times:         ArgProperty[Int]               = ArgProperty[Int](),
                          include:       ArgProperty[String]            = ArgProperty[String](),
                          exclude:       ArgProperty[String]            = ArgProperty[String](),
                          was:           ArgProperty[String]            = ArgProperty[String](),
                          selector:      ArgProperty[String]            = ArgProperty[String]()) = updateArguments(super.select(
       ex,
+      times,
       include,
       exclude,
       was,


### PR DESCRIPTION
For example:
`sbt test-only *MySpec* -- times 10`
will run `MySpec` ten times in a row!

Motivation for this: When testing nondeterministic code, sometimes a test will only sometimes fail. In that case, my current way to run a spec multiple times is:

`; test-only *MySpec*; test-only *MySpec*; test-only *MySpec*; ...`

And that's tedious.