### PR TITLE
fix showOnly flag to exclude title

### DIFF
--- a/core/src/test/scala/org/specs2/reporter/TextPrinterSpec.scala
+++ b/core/src/test/scala/org/specs2/reporter/TextPrinterSpec.scala
@@ -1,14 +1,14 @@
 package org.specs2
 package reporter
 
-import matcher.{MustMatchers}
+import matcher.MustMatchers
 import specification._
-import dsl.{FragmentsDsl}
-import specification.create.{DefaultFragmentFactory}
+import dsl.FragmentsDsl
+import specification.create.DefaultFragmentFactory
 import control._
 import text.Trim._
 import execute._
-import org.specs2.main.{Arguments}
+import org.specs2.main.{Arguments, Report}
 import LineLogger._
 import core._
 import process.{Stats, DefaultExecutor, StatisticsRepository}
@@ -84,8 +84,8 @@ class TextPrinterSpec extends Specification { def is = s2"""
       """|[info] title"""
 
   def a2 =
-    showOnly("#") ^ "title".title ^ "" doesntContain
-    """|[info] title"""
+    showOnly(Report.allFlags.filterNot(_ == '#')) ^ "title".title ^ "" doesntContain
+      """|[info] title"""
 
   def a3 = "title".title ^ s2"""
 presentation


### PR DESCRIPTION
fix this error (might be from https://github.com/etorreborre/specs2/commit/7f9efd99fccbc465fa3481911824790170e58ccf).

```
[error] x the title is not displayed if # can not be shown
[error]  '[info]_title' contains '[info]_title' (file:1)

[error] Failed: Total 719, Failed 1, Errors 0, Passed 718
[error] Failed tests:
[error] 	org.specs2.reporter.TextPrinterSpec
```