### PR TITLE
Make EventuallyResults consistent with EventuallyMatchers

### DIFF
--- a/common/src/main/scala/org/specs2/execute/EventuallyResults.scala
+++ b/common/src/main/scala/org/specs2/execute/EventuallyResults.scala
@@ -13,22 +13,26 @@ trait EventuallyResults {
   /**
    * @return a matcher that will retry the nested matcher a given number of times
    */
-  def eventually[T : AsResult](retries: Int, sleep: Duration)(result: =>T): Result = {
-    def retry(retries: Int, sleep: Duration, r: =>T): Result = {
-      lazy val t = r
-      val result = ResultExecution.execute(t)(AsResult(_))
-      if (result.isSuccess || retries <= 1)
-        result
-      else {
-        Thread.sleep(sleep.toMillis)
-        retry(retries - 1, sleep, r)
+  def eventually[T : AsResult](retries: Int, sleep: Duration)(result: =>T): T = {
+    def retry(retries: Int, sleep: Duration, r: =>T): T = {
+      if (retries <= 1) {
+        r
+      } else {
+        lazy val t = r
+        val result = ResultExecution.execute(t)(AsResult(_))
+        if (result.isSuccess)
+          t
+        else {
+          Thread.sleep(sleep.toMillis)
+          retry(retries - 1, sleep, r)
+        }
       }
     }
     retry(retries, sleep, result)
   }
 
   /** @return a result that is retried at least 40 times until it's ok */
-  def eventually[T : AsResult](result: =>T): Result =
+  def eventually[T : AsResult](result: =>T): T =
     eventually(40, 100.millis)(result)
 }
 

--- a/core/src/test/scala/org/specs2/execute/EventuallyResultsSpec.scala
+++ b/core/src/test/scala/org/specs2/execute/EventuallyResultsSpec.scala
@@ -44,6 +44,6 @@ class EventuallyResultsSpec extends Specification with ResultMatchers {
     }
     val m = mock(classOf[ToMock])
     (1 to 3).foreach(i => doReturn(i).when(m).next)
-    eventually(m.next == 3) must beSuccessful
+    eventually(m.next must_== 3) must beSuccessful
   }
 }


### PR DESCRIPTION
This changes the API so that the eventually returns again.
This will make specs that were built under this assumption continue to work as expected.

The following example used to return an error prior the commit 471cd6c8ad97d, but now it will pass:
```
"example" in {
  eventually {
    ko
  } // previously we weren't required to do a `must beSuccessful` here
  ok
}
```
This means that all existing specs using `eventually` this way, aren't currently able to see the error and the test will always pass.

The previous issue #462 was kept resolved.