### PR TITLE
adding generics to BaseMatcher in HamcrestMatcherAdapter

### DIFF
--- a/mock/src/main/scala/org/specs2/mock/HamcrestMatcherAdapter.scala
+++ b/mock/src/main/scala/org/specs2/mock/HamcrestMatcherAdapter.scala
@@ -7,7 +7,7 @@ import matcher._
 /** 
  * Adapter class to use specs2 matchers as Hamcrest matchers 
  */
-case class HamcrestMatcherAdapter[T](m: Matcher[T]) extends BaseMatcher {
+case class HamcrestMatcherAdapter[T](m: Matcher[T]) extends BaseMatcher[T] {
   /** this variable is necessary to store the result of a match */ 
   private var message = ""
     


### PR DESCRIPTION
hey @etorreborre,
I'm trying to use the HamcrestMathcerAdapter (since i like specs2 matchers much more...) but i had some trouble doing that since this case class does not extend Matcher[T].
was the `[T]` left out by mistake or in purpose?
Thanks!