### PR TITLE
Issue #499 - set sidebar size for narrow screens

### DIFF
--- a/html/src/main/resources/org/specs2/reporter/templates/specs2.html
+++ b/html/src/main/resources/org/specs2/reporter/templates/specs2.html
@@ -29,7 +29,7 @@
 <div class="container">
 
 $if(sidebar)$
-<div class="col-md-2 sidebar-outer">
+<div class="col-md-2 col-sm-3 col-xs-3 sidebar-outer">
 <div class="col-md-2 fixed">
 $else$
 <div class="col-md-1"></div>
@@ -59,7 +59,7 @@ $else$
 $endif$
 
 
-<div class="col-md-10">
+<div class="col-md-10 col-sm-9 col-xs-9">
 $if(issues)$
 <h1>$title$
     <a href="#" onclick="hideByClass('ok');hideById('onlyIssuesLink');showById('allElementsLink')"><span id=onlyIssuesLink class="issues-toggle"> (issues only)</span></a>


### PR DESCRIPTION
While I have the project open - this should help with the problem mentioned on Issue #499 where the nav bar overlaps the main content on small screens. 
(I'm not a designer either but adding those Bootstrap size hints in the Chrome developer tools solved the problem when resizing the browser window)