### PR TITLE
describeTo works to show the expected result

### DIFF
--- a/mock/src/main/scala/org/specs2/mock/HamcrestMatcherAdapter.scala
+++ b/mock/src/main/scala/org/specs2/mock/HamcrestMatcherAdapter.scala
@@ -22,7 +22,7 @@ case class HamcrestMatcherAdapter[T](m: Matcher[T]) extends BaseMatcher[T] {
     val i = if (item != null && item.isInstanceOf[Function0[_]]) item.asInstanceOf[Function0[_]].apply().asInstanceOf[A] else item
     try {
       matcher.apply(Expectable(i)) match {
-        case f: MatchFailure[_] => message = f.koMessage; false
+        case f: MatchFailure[_] => message = f.okMessage; false
         case _ => true
       }
     // a class cast exception can happen if we tried: vet.treat(dog); there must be one(vet).treat(bird) (see issue #222)


### PR DESCRIPTION
hey @etorreborre,
continuing my HamcrestMatcherAdapter saga... =)
so it appears that the describeTo uses its description to show the expected result.
the current implementation creates weird results. 
for example:

``` scala
  @Test
  def hamcrest = {
    val matcher: Matcher[Boolean] = beTrue
    assertThat(false, matcher) // there's an implicit conversion here, but it just uses the adapter
  }
```

outputs:

```
Expected: the value is false
     but: was <false>
```

which is quite confusing...

i don't think my change is the best, i'm just not sure how to solve this...

thanks,
Nadav
