### PR TITLE
make version-specific source directories work in community build

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -192,10 +192,18 @@ object build extends Build {
     (if (name == "specs2") "" else name) + "> "
   }
 
+  def scalaSourceVersion(scalaBinaryVersion: String) =
+    if (scalaBinaryVersion.startsWith("2.10"))
+      "2.10"
+    else if (scalaBinaryVersion.startsWith("2.11"))
+      "2.11"
+    else
+      "2.12.0-RC1"
+
   lazy val compilationSettings: Seq[Settings] = Seq(
     // https://gist.github.com/djspiewak/976cd8ac65e20e136f05
     unmanagedSourceDirectories in Compile ++=
-      Seq((sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}",
+      Seq((sourceDirectory in Compile).value / s"scala-${scalaSourceVersion(scalaBinaryVersion.value)}",
           if (scalazVersion.value.startsWith("7.0")) (sourceDirectory in Compile).value / s"scala-scalaz-7.0.x"
           else                                       (sourceDirectory in Compile).value / s"scala-scalaz-7.1.x",
           if (scalazVersion.value.startsWith("7.0")) (sourceDirectory in (Test, test)).value / s"scala-scalaz-7.0.x"


### PR DESCRIPTION
I'm trying to move the Scala 2.12 community build to use specs2's
master branch, rather than a fork.

in the context of the community build, the Scala version number
(including the scalaBinaryVersion) is liable to be something like
"Scala 2.12.0-1f6006d-nightly", so anything that inspects the Scala
version should be robust about inspecting only the beginning.

these long Scala version numbers also break the trick you're doing of
using the Scala binary version verbatim as the name of a
Scala-version-specific directory.

so this commit changes that logic in a way that works for the
community build.  maybe not in the best way, maybe you'll want to do
it your own way instead, especially since RC2 is on the way and at the
moment you're using "2.12.0-RC1" as a directory name.  but anyway, but
in any case, here's one possible fix.