### PR TITLE
Adds compatibility with Scalaz 7.3.

### DIFF
--- a/common/src/main/scala/org/specs2/control/eff/AsyncFutureInterpreter.scala
+++ b/common/src/main/scala/org/specs2/control/eff/AsyncFutureInterpreter.scala
@@ -140,16 +140,16 @@ object AsyncFutureInterpreter {
     override def toString = "Applicative[Future]"
   }
 
-  implicit def FutureMonad(implicit ec: ExecutionContext): Monad[Future] with BindRec[Future] = new Monad[Future] with BindRec[Future] {
+  implicit def FutureMonad(implicit ec: ExecutionContext): Monad[Future] with BindRecʹ[Future] = new Monad[Future] with BindRecʹ[Future] {
     def point[A](x: =>A): Future[A] =
       Future.successful(x)
 
     def bind[A, B](fa: Future[A])(f: A => Future[B]): Future[B] =
       fa.flatMap(f)
 
-    def tailrecM[A, B](f: A => Future[A \/ B])(a: A): Future[B] =
+    def tailrecM[A, B](a: A)(f: A => Future[A \/ B]): Future[B] =
       FutureMonad.bind(f(a)) {
-        case -\/(a1) => tailrecM(f)(a1)
+        case -\/(a1) => tailrecM(a1)(f)
         case \/-(b) => FutureMonad.point(b)
       }
 

--- a/common/src/main/scala/org/specs2/control/eff/BindRecʹ.scala
+++ b/common/src/main/scala/org/specs2/control/eff/BindRecʹ.scala
@@ -1,0 +1,14 @@
+package org.specs2.control.eff
+
+import scalaz._
+
+/** Papers over the parameter order change in Scalaz 7.3 */
+trait BindRecʹ[M[_]] extends BindRec[M] {
+
+  def tailrecM[A, B](a: A)(f: A => M[\/[A, B]]): M[B]
+
+  // TODO: Needed for compatibility with Scalaz prior to 7.3
+  def tailrecM[A, B](f: A => M[\/[A, B]])(a: A): M[B] =
+    tailrecM(a)(f)
+
+}

--- a/common/src/main/scala/org/specs2/control/eff/syntax/eff.scala
+++ b/common/src/main/scala/org/specs2/control/eff/syntax/eff.scala
@@ -27,13 +27,13 @@ trait eff {
   }
 
   implicit class EffOneEffectOps[M[_] : Monad, A](e: Eff[Fx1[M], A]) {
-    def detach(implicit bindRec: BindRec[M]): M[A] =
+    def detach(implicit bindRec: BindRecʹ[M]): M[A] =
       Eff.detach(e)
 
   }
 
   implicit class EffOneEffectApplicativeOps[M[_] : Monad, A](e: Eff[Fx1[M], A]) {
-    def detachA(implicit bindRec: BindRec[M], applicative: Applicative[M]): M[A] =
+    def detachA(implicit bindRec: BindRecʹ[M], applicative: Applicative[M]): M[A] =
       Eff.detachA(e)(implicitly[Monad[M]], bindRec, applicative)
   }
 

--- a/common/src/main/scala/org/specs2/data/Trees.scala
+++ b/common/src/main/scala/org/specs2/data/Trees.scala
@@ -4,7 +4,7 @@ package data
 import scalaz.{Tree, TreeLoc}
 import scalaz.syntax.foldable._
 import scalaz.std.stream._
-import Tree.{node => Node, leaf => Leaf}
+import Tree.{Node, Leaf}
 
 /**
  * Utility methods for scalaz Trees

--- a/core/src/main/scala/org/specs2/specification/dsl/mutable/EffectBlocks.scala
+++ b/core/src/main/scala/org/specs2/specification/dsl/mutable/EffectBlocks.scala
@@ -34,7 +34,7 @@ case class EffectBlocks(var mode: EffectBlocksMode = Record) {
    * run a specification in the "isolation" mode were the changes in local variables belonging to blocks are not seen by
    * other examples
    */
-  private[specs2] var blocksTree: TreeLoc[Int] = leaf(0).loc
+  private[specs2] var blocksTree: TreeLoc[Int] = Leaf(0).loc
 
   private[specs2] def paths: List[EffectPath] =
     blocksTree.toTree.allPaths.map(p => EffectPath(p:_*))
@@ -48,7 +48,7 @@ case class EffectBlocks(var mode: EffectBlocksMode = Record) {
 
   def clear = {
     effects.clear
-    blocksTree = leaf(0).loc
+    blocksTree = Leaf(0).loc
     this
   }
 
@@ -76,7 +76,7 @@ case class EffectBlocks(var mode: EffectBlocksMode = Record) {
   def replay(targetPath: EffectPath) = {
     mode = Replay
     // in replay mode don't update the blocksTree
-    blocksTree = leaf(0).loc
+    blocksTree = Leaf(0).loc
 
     def runPath(path: Seq[Int]): Unit = {
       path.toList match {
@@ -148,8 +148,8 @@ case class EffectBlocks(var mode: EffectBlocksMode = Record) {
 
   implicit class TreeLocx[T](t: TreeLoc[T]) {
     def getParent = t.parent.getOrElse(t)
-    def addChild(c: T) = t.insertDownLast(leaf(c)).getParent
-    def insertDownLast(c: T) = t.insertDownLast(leaf(c))
+    def addChild(c: T) = t.insertDownLast(Leaf(c)).getParent
+    def insertDownLast(c: T) = t.insertDownLast(Leaf(c))
   }
 
 }

--- a/tests/src/test/scala/org/specs2/data/TreesSpec.scala
+++ b/tests/src/test/scala/org/specs2/data/TreesSpec.scala
@@ -26,7 +26,7 @@ class TreesSpec extends Specification with ScalaCheck with ThrownExpectations { 
   def genTree(root: Int, nodes: List[Int]): Gen[TreeAndPaths] =
     nodes match {
       case Nil =>
-        Gen.const(TreeAndPaths(Tree.leaf(root), List(List(root))))
+        Gen.const(TreeAndPaths(Tree.Leaf(root), List(List(root))))
       case _ =>
         genTreeList(nodes).map { ls =>
           TreeAndPaths(Tree.Node(root, ls.toStream.map(_.tree)), ls.flatMap(l => l.paths.map(root :: _)))


### PR DESCRIPTION
Fixes #530.

- use `Leaf` rather than `leaf`, etc. for `scalaz.Tree`
- provide `BindRecʹ` to support both pre- and post-7.3 signatures of `tailrecM`