### PR TITLE
Array equality fix

### DIFF
--- a/matcher/src/main/scala/org/specs2/matcher/describe/Diffable.scala
+++ b/matcher/src/main/scala/org/specs2/matcher/describe/Diffable.scala
@@ -67,3 +67,5 @@ trait Diffables {
       }
   }
 }
+
+object Diffables extends Diffables

--- a/matcher/src/main/scala/org/specs2/matcher/describe/Diffable.scala
+++ b/matcher/src/main/scala/org/specs2/matcher/describe/Diffable.scala
@@ -67,5 +67,3 @@ trait Diffables {
       }
   }
 }
-
-object Diffables extends Diffables

--- a/matcher/src/main/scala/org/specs2/matcher/describe/Diffables.scala
+++ b/matcher/src/main/scala/org/specs2/matcher/describe/Diffables.scala
@@ -188,12 +188,9 @@ class ArrayDiffable[E](implicit di: Diffable[E]) extends Diffable[Array[E]] {
 class FallbackDiffable[T] extends Diffable[T] {
   def diff(actual: T, expected: T) = {
     (actual, expected) match {
-      case (e1: Array[_], e2: Array[_]) =>
-        Diffable.arrayDiffable[Any].diff(e1.map(a => a:Any), e2.map(a => a:Any))
-
-      case _ =>
-        if (actual == expected) OtherIdentical(actual)
-        else                    OtherDifferent(actual, expected)
+      case (e1: Array[_], e2: Array[_]) =>  Diffable.diff(e1.map(a => a:Any), e2.map(a => a:Any))
+      case (a, e) if a == e =>              OtherIdentical(a)
+      case (a, e) =>                        OtherDifferent(a, e)
     }
   }
 }


### PR DESCRIPTION
Hi @etorreborre,
I have a suggestion for the array fix you checked in.
On your fix you are forcing diffable by exposing internals by the Diffables companion object.
I prefer to keep the code flow stricter, so in case we have array (which is a special case) we will state it to the compiler and let it resolve the diffable in the same manner it does for all diffables.
WDYT ?

 - Noam