### PR TITLE
Add a Matcher to assert a Task can fail with a specific Exception

### DIFF
--- a/scalaz/src/main/scala-scalaz-7.0.x/org/specs2/matcher/TaskMatchers.scala
+++ b/scalaz/src/main/scala-scalaz-7.0.x/org/specs2/matcher/TaskMatchers.scala
@@ -1,9 +1,12 @@
 package org.specs2
 package matcher
 
+import AnyMatchers._
+import DisjunctionMatchers._
 import ValueChecks._
 import org.specs2.matcher.describe.Diffable
 
+import scala.reflect.ClassTag
 import scalaz.concurrent.Task
 import text.NotNullStrings._
 
@@ -17,6 +20,9 @@ trait TaskMatchers {
 
   def returnValue[T](check: ValueCheck[T]): TaskMatcher[T] =
     attemptRun(check)
+
+  def failWith[T <: Throwable : ClassTag]: Matcher[Task[_]] =
+    returnValue(be_-\/(haveClass[T])) ^^ { t: Task[_] => t.attempt }
 
   private[specs2] def attemptRun[T](check: ValueCheck[T]): TaskMatcher[T] =
     TaskMatcher(check)

--- a/scalaz/src/main/scala-scalaz-7.1.x/org/specs2/matcher/TaskMatchers.scala
+++ b/scalaz/src/main/scala-scalaz-7.1.x/org/specs2/matcher/TaskMatchers.scala
@@ -5,8 +5,11 @@ import scala.concurrent.TimeoutException
 import scala.concurrent.duration.Duration
 import scalaz.concurrent.Task
 import text.NotNullStrings._
+import AnyMatchers._
+import DisjunctionMatchers._
 import ValueChecks._
 import org.specs2.matcher.describe.Diffable
+import scala.reflect.ClassTag
 
 /**
  * Matchers for scalaz.concurrent.Task
@@ -21,6 +24,9 @@ trait TaskMatchers {
 
   def returnBefore[T](duration: Duration): TaskMatcher[T] =
     attemptRun(ValueCheck.alwaysOk, Some(duration))
+
+  def failWith[T <: Throwable : ClassTag]: Matcher[Task[_]] =
+    returnValue(be_-\/(haveClass[T])) ^^ { t: Task[_] => t.attempt }
 
   private[specs2] def attemptRun[T](check: ValueCheck[T], duration: Option[Duration]): TaskMatcher[T] =
     TaskMatcher(check, duration)

--- a/tests/src/test/scala/org/specs2/matcher/TaskMatchersSpec.scala
+++ b/tests/src/test/scala/org/specs2/matcher/TaskMatchersSpec.scala
@@ -21,5 +21,13 @@ class TaskMatchersSpec extends mutable.Spec with TaskMatchers with ResultMatcher
       { Task { Thread.sleep(5); 1 } must returnBefore(10.millis).withValue(1) }
       { Task { Thread.sleep(5); 1 } must returnValue(1).before(10.millis) }
     }
+
+    "check that the task fails with a specific type of exception" >> {
+      val a: Task[String] = Task.fail(new NullPointerException)
+
+      { a must failWith[NullPointerException] }
+      { (a must failWith[IllegalArgumentException]) must beFailing }
+      { (Task(3) must failWith[Exception]) must beFailing }
+    }
   }
 }


### PR DESCRIPTION
Since I am not too familiar with the scalaz cross building in specs2, I have only added my changes to the currently active version of TaskMatchers/TaskMatchersSpec. Please let me know if I also need to include it in the other versions.

I have chosen the name `failWith` for my matcher, which is already used in a couple of other places: there should no conflicts, but again, let me know if you'd rather have it named differently.