### PR TITLE
Fix retry in await helper

### DIFF
--- a/common/src/main/scala/org/specs2/concurrent/FutureAwait.scala
+++ b/common/src/main/scala/org/specs2/concurrent/FutureAwait.scala
@@ -11,7 +11,7 @@ import scalaz._, Scalaz._
  * number of retries
  */
 trait FutureAwait {
-  implicit class AwaitFuture[T](f: Future[T])(implicit ee: ExecutionEnv) {
+  implicit class AwaitFuture[T](f: => Future[T])(implicit ee: ExecutionEnv) {
     def await: TimeoutFailure \/ T =
       await(retries = 0, timeout = 1.second)
 


### PR DESCRIPTION
This PR fixes the retry mechanism in the `await` helper. Since `Future` results are cached, `Future`s weren't being properly retried in case of timeouts.