### PR TITLE
Add explicit type to implicit val used before definition.

### DIFF
--- a/matcher/src/main/scala/org/specs2/matcher/MatchResultMessages.scala
+++ b/matcher/src/main/scala/org/specs2/matcher/MatchResultMessages.scala
@@ -16,7 +16,7 @@ trait MatchResultMessages {
       case _                  => NeutralMessage(r.message)
     }}
 
-  implicit val MatchResultMessageMonoid = new Monoid[MatchResultMessage] {
+  implicit val MatchResultMessageMonoid: Monoid[MatchResultMessage] = new Monoid[MatchResultMessage] {
     val zero = new EmptySuccessMessage()
     def append(r1: MatchResultMessage, r2: =>MatchResultMessage) = r1 append r2
   }


### PR DESCRIPTION
Implicits that rely on an inferred return type may not be in scope above their point of definition. In this case, the use comes right before the implicit definition and leads to compilation errors in incremental updates.

You can observe the failure by adding a whitespace to the file and trying to compile (after a full build, so the only file to compile is this one).

See [this thread](https://contributors.scala-lang.org/t/implicits-with-inferred-return-type-lead-to-undefined-behavior/615).