### PR TITLE
Make TypedEqual object extend the trait

### DIFF
--- a/matcher/src/main/scala/org/specs2/matcher/TypedEqual.scala
+++ b/matcher/src/main/scala/org/specs2/matcher/TypedEqual.scala
@@ -27,7 +27,7 @@ trait TypedEqual { this: ExpectationsCreation =>
   }
 }
 
-object TypedEqual extends ExpectationsCreation
+object TypedEqual extends TypedEqual with ExpectationsCreation
 /**
  * This trait can be used to suppress the TypedEqual implicit
  */


### PR DESCRIPTION
I am trying to get the `===` operator available outside of a specification definition. It looks to me like the `TypedEqual` object is for that, but it does not extend the `TypedEqual` trait. That looks like a mistake to me but I'm not overly familiar with the `specs2` codebase so apologies in advance if this is not the case.