### PR TITLE
use `Diffable.identical` for `CaseClassPropertyComparison.identical`

### DIFF
--- a/shapeless/src/main/scala/org/specs2/matcher/describe/CaseClassIntrospection.scala
+++ b/shapeless/src/main/scala/org/specs2/matcher/describe/CaseClassIntrospection.scala
@@ -66,9 +66,11 @@ class ClassFieldsDifferenceInspectable[Key <: Symbol, Value, Tail <: HList](
             .diff(actual.tail, expected.tail)
             .prepend( compareHead(key.value.name, actual.head, expected.head) )
 
-  private def compareHead(fieldName: String, actual: Value, expected: Value) =
+  private def compareHead(fieldName: String, actual: Value, expected: Value) = {
+    val compResult = di.diff(actual, expected)
     CaseClassPropertyComparison(fieldName = fieldName,
-                            result = di.diff(actual, expected),
-                            identical = actual == expected)
+      result = compResult,
+      identical = compResult.identical)
+  }
 }
 

--- a/tests/src/test/scala/org/specs2/matcher/describe/DiffableSpec.scala
+++ b/tests/src/test/scala/org/specs2/matcher/describe/DiffableSpec.scala
@@ -107,6 +107,11 @@ Compare result
   Comparing failure with success will return type difference    ${ Diffable.diff(Try("abc"), Failure[String](ex2)) must_=== TryTypeDifferent(isActualSuccess = true) }
   todo: handle non explicit types for Failure !!!
 
+  Case Classes
+  ============
+
+  Allow using custom Diffable for case class fields $ccFieldDiffable
+
 
     We need to support different type compare
 """
@@ -146,6 +151,17 @@ Compare result
       }
   }
 
+  def ccFieldDiffable = {
+    case class A(value: Int)
+    case class B(name: String, value: A)
+    implicit val diffableA: Diffable[A] = new Diffable[A] {
+      def diff(actual: A, expected: A): ComparisonResult = CaseClassIdentical("A")
+    }
+    val name = "name"
+    val b1 = B(name, A(5))
+    val b2 = B(name, A(6))
+    Diffable.diff(b1, b2) must_== CaseClassIdentical("B")
+  }
 }
 
 


### PR DESCRIPTION
instead of `actual == expected`