### PR TITLE
fix regression bug

### DIFF
--- a/matcher/src/main/scala/org/specs2/matcher/describe/Diffables.scala
+++ b/matcher/src/main/scala/org/specs2/matcher/describe/Diffables.scala
@@ -63,6 +63,7 @@ class OptionDiffable[T : Diffable](implicit di: Diffable[T]) extends Diffable[Op
         val result = di.diff(a, e)
         if (result.identical) OptionIdentical(Some(result))
         else OptionDifferent(result)
+      case (None, None) => OptionIdentical(None)
       case _ => OptionTypeDifferent(actual.isDefined, expected.isDefined)
     }
 }

--- a/tests/src/test/scala/org/specs2/matcher/describe/DiffableSpec.scala
+++ b/tests/src/test/scala/org/specs2/matcher/describe/DiffableSpec.scala
@@ -81,6 +81,7 @@ Compare result
     None and Some will return OptionDifferent                     ${ Diffable.diff(None, Option("abc")) must_=== OptionTypeDifferent(isActualSome = false, isExpectedSome = true) }
     Some(x) and Some(y) will return OptionDifferent with result   ${ Diffable.diff(Option("abc"), Option("def")) must_=== OptionDifferent(PrimitiveDifference("abc", "def")) }
     two None will return OptionIdentical                          ${ Diffable.diff(None, None) must_=== OptionIdentical(None) }
+    two (None: Option[String]) will return OptionIdentical        ${ Diffable.diff((None: Option[String]), (None: Option[String])) must_=== OptionIdentical(None) }
     two identical Some will return OptionIdentical                ${ Diffable.diff(Some("abc"), Some("abc")) must_=== OptionIdentical(Some(PrimitiveIdentical("abc"))) }
 
 


### PR DESCRIPTION
accidentally left out the `(None, None)` case when enabling nested `Diffable`s for equivalence checks.