### PR TITLE
update sbt plugin version

### DIFF
--- a/.travis-test.sh
+++ b/.travis-test.sh
@@ -1,2 +1,2 @@
-sbt -jvm-opts .travis.jvmopts -sbt-version 0.13.15 -scala-version $TRAVIS_SCALA_VERSION ";set parallelExecution in ThisBuild := false; $1/testOnly -- xonly timefactor 3 neverstore exclude travis"
+sbt -jvm-opts .travis.jvmopts -sbt-version 0.13.16 -scala-version $TRAVIS_SCALA_VERSION ";set parallelExecution in ThisBuild := false; $1/testOnly -- xonly timefactor 3 neverstore exclude travis"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,19 +1,7 @@
 import sbt._
-import complete.DefaultParsers._
 import Keys._
-import com.typesafe.sbt._
-import pgp.PgpKeys._
-import SbtSite._
-import SiteKeys._
-import SbtGit._
-import GitKeys._
-import SbtGhPages._
-import GhPagesKeys._
 import Defaults._
-import xerial.sbt.Sonatype._
-import SonatypeKeys._
-import depends._
-import ohnosequences.sbt.GithubRelease.keys._
+import com.typesafe.sbt.pgp.PgpKeys._
 
 /** MAIN PROJECT */
 lazy val specs2 = Project(
@@ -28,7 +16,7 @@ lazy val specs2 = Project(
   shapelessJvm, form, markdown, gwt, junitJvm, scalacheckJvm, mockJvm, tests,
   fpJs, commonJs, matcherJs, coreJs, matcherExtraJs, scalazJs, analysisJs,
   shapelessJs, form, junitJs, scalacheckJs, mockJs)
-  .enablePlugins(GitBranchPrompt).enablePlugins(ScalaJSPlugin)
+  .enablePlugins(GitBranchPrompt, ScalaJSPlugin, GhpagesPlugin)
 
 /** COMMON SETTINGS */
 lazy val specs2Settings = Seq(
@@ -328,19 +316,19 @@ lazy val testingJvmSettings =
 /**
  * DOCUMENTATION
  */
-lazy val siteSettings = ghpages.settings ++ SbtSite.site.settings ++
+lazy val siteSettings = GhpagesPlugin.projectSettings ++ SitePlugin.projectSettings ++
   Seq(
     siteSourceDirectory := target.value / "specs2-reports" / "site",
     // copy the api files to a versioned directory
     siteMappings ++= { (mappings in packageDoc in Compile).value.map { case (f, d) => (f, s"api/SPECS2-${version.value}/$d") } },
     includeFilter in makeSite := AllPassFilter,
     // override the synchLocal task to avoid removing the existing files
-    synchLocal := {
-      val betterMappings = privateMappings.value map { case (file, target) => (file, updatedRepository.value / target) }
+    ghpagesSynchLocal := {
+      val betterMappings = ghpagesPrivateMappings.value map { case (file, target) => (file, ghpagesUpdatedRepository.value / target) }
       IO.copy(betterMappings)
-      updatedRepository.value
+      ghpagesUpdatedRepository.value
     },
-    gitRemoteRepo := "git@github.com:etorreborre/specs2.git"
+    git.remoteRepo := "git@github.com:etorreborre/specs2.git"
   )
 
 /**
@@ -376,7 +364,7 @@ lazy val publicationSettings = Seq(
     ),
   credentials := Seq(Credentials(Path.userHome / ".sbt" / "specs2.credentials"))
 ) ++
-  sonatypeSettings
+  Sonatype.projectSettings
 
 /**
  * NOTIFICATION

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,8 @@
-addSbtPlugin("org.scala-js"      % "sbt-scalajs"        % "0.6.18")
-addSbtPlugin("com.jsuereth"      % "sbt-pgp"            % "1.0.0")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-site"           % "0.6.2")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-ghpages"        % "0.5.1")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-git"            % "0.8.0")
-addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"       % "0.4.0")
-addSbtPlugin("com.orrsella"      % "sbt-stats"          % "1.0.5")
+addSbtPlugin("org.scala-js"      % "sbt-scalajs"        % "0.6.20")
+addSbtPlugin("com.jsuereth"      % "sbt-pgp"            % "1.1.0")
+addSbtPlugin("com.typesafe.sbt"  % "sbt-ghpages"        % "0.6.2")
+addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"       % "2.0")
+addSbtPlugin("com.orrsella"      % "sbt-stats"          % "1.0.7")
 addSbtPlugin("ohnosequences"     % "sbt-github-release" % "0.4.0")
 
 resolvers += "Era7 maven releases" at "https://s3-eu-west-1.amazonaws.com/releases.era7.com"

--- a/sbt
+++ b/sbt
@@ -103,7 +103,7 @@ init_default_option_file () {
 
 declare -r cms_opts="-XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
 declare -r jit_opts="-XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation"
-declare -r default_jvm_opts_common="-Xms512m -Xmx1536m -Xss2m $jit_opts $cms_opts"
+declare -r default_jvm_opts_common="-Xms1024m -Xmx3072m -Xss2m $jit_opts $cms_opts"
 declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
 declare -r latest_28="2.8.2"
 declare -r latest_29="2.9.3"


### PR DESCRIPTION
When starting sbt, the following warning is issued, so updated the version of sbt plugins.

[warn] Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[warn] 
[warn] 	* com.typesafe.sbt:sbt-git:0.8.0 is selected over 0.6.1
[warn] 	    +- default:specs2-build:0.1-SNAPSHOT (scalaVersion=2.10, sbtVersion=0.13) (depends on 0.8.0)
[warn] 	    +- com.typesafe.sbt:sbt-ghpages:0.5.1 (scalaVersion=2.10, sbtVersion=0.13) (depends on 0.6.1)
[warn] 
[warn] Run 'evicted' to see detailed eviction warnings
