### PR TITLE
removed sbt version specification from travis settings

### DIFF
--- a/.travis-test.sh
+++ b/.travis-test.sh
@@ -1,2 +1,2 @@
-sbt -jvm-opts .travis.jvmopts -sbt-version 0.13.16 -scala-version $TRAVIS_SCALA_VERSION ";set parallelExecution in ThisBuild := false; $1/testOnly -- xonly timefactor 3 neverstore exclude travis"
+sbt -jvm-opts .travis.jvmopts -scala-version $TRAVIS_SCALA_VERSION ";set parallelExecution in ThisBuild := false; $1/testOnly -- xonly timefactor 3 neverstore exclude travis"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: scala
 
 scala:
-  - 2.12.2
+  - 2.12.3
 
 jdk:
   - oraclejdk8
@@ -20,7 +20,7 @@ before_cache:
   - find $HOME/.sbt        -name "*.lock"               -print -delete
 
 script:
-  - sbt -jvm-opts .travis.jvmopts -sbt-version 0.13.16 -scala-version $TRAVIS_SCALA_VERSION ';clean ;test:compile'
+  - sbt -jvm-opts .travis.jvmopts -scala-version $TRAVIS_SCALA_VERSION ';clean ;test:compile'
   - ./.travis-test.sh coreJVM
   - ./.travis-test.sh examplesJVM
   - ./.travis-test.sh junitJVM


### PR DESCRIPTION
Version of sbt should be specified in project/build.properties

In addition, the version of travis' scala is old(2.12.2), so I modified it to match build.sbt(2.12.3).

It is confirmed that travis of my repository has succeeded this time :)