### PR TITLE
Add missing override to MutableBangExample

### DIFF
--- a/core/src/main/scala/org/specs2/specification/dsl/mutable/ExampleDsl.scala
+++ b/core/src/main/scala/org/specs2/specification/dsl/mutable/ExampleDsl.scala
@@ -24,6 +24,7 @@ trait ExampleDsl extends ExampleDsl1 with dsl.ExampleDsl {
     new MutableBangExample(d)
 
   class MutableBangExample(d: String) extends BangExample(d) {
+    override def !(execution: Execution): Fragment                                       = addFragment(fragmentFactory.example(Text(d), execution))
     override def ![R : AsResult](r: => R): Fragment                                      = addFragment(fragmentFactory.example(d, r))
     override def ![R : AsResult](r: String => R): Fragment                               = addFragment(fragmentFactory.example(d, r))
     override def ![R](r: Env => R)(implicit as: AsResult[R], p: ImplicitParam): Fragment = addFragment(fragmentFactory.example(d, r)(as, p))


### PR DESCRIPTION
The default (immutable) implementation for this `!` overload doesn't add the fragment it produces. This means the fragment can be lost when writing tests in mutable style.

This fix should be also ported to master.