### PR TITLE
Fix multiple typos

### DIFF
--- a/common/shared/src/main/scala/org/specs2/control/Property.scala
+++ b/common/shared/src/main/scala/org/specs2/control/Property.scala
@@ -19,7 +19,7 @@ case class Property[T](value: () => Option[T], evaluated: Boolean = false, evalu
   def toOption: Option[T] = optionalValue
   /** update the value */
   def update(newValue: =>T) = withValue(newValue)
-  /** alial for update */
+  /** alias for update */
   def apply(newValue: =>T) = update(newValue)
   /** @return an iterator containing the value if present */
   def iterator = optionalValue.iterator

--- a/common/shared/src/main/scala/org/specs2/control/StackTraceFilter.scala
+++ b/common/shared/src/main/scala/org/specs2/control/StackTraceFilter.scala
@@ -51,15 +51,15 @@ case class IncludeExcludeStackTraceFilter(include: Seq[String], exclude: Seq[Str
  */
 object IncludeExcludeStackTraceFilter {
   def fromString(s: String): StackTraceFilter = {
-    val splitted = s.split("/").toSeq
-    if (splitted.size == 0)
+    val split = s.split("/").toSeq
+    if (split.size == 0)
       new IncludeExcludeStackTraceFilter(Seq[String](), Seq[String]())
-    else if (splitted.size == 1)
-      new IncludeExcludeStackTraceFilter(splitted(0).splitTrim(","), Seq[String]())
-    else if (splitted.size == 2)
-      new IncludeExcludeStackTraceFilter(splitted(0).splitTrim(","), splitted(1).splitTrim(","))
+    else if (split.size == 1)
+      new IncludeExcludeStackTraceFilter(split(0).splitTrim(","), Seq[String]())
+    else if (split.size == 2)
+      new IncludeExcludeStackTraceFilter(split(0).splitTrim(","), split(1).splitTrim(","))
     else
-      new IncludeExcludeStackTraceFilter(splitted(0).splitTrim(","), splitted.drop(1).mkString(",").splitTrim(","))
+      new IncludeExcludeStackTraceFilter(split(0).splitTrim(","), split.drop(1).mkString(",").splitTrim(","))
   }
 }
 

--- a/common/shared/src/main/scala/org/specs2/execute/Snippets.scala
+++ b/common/shared/src/main/scala/org/specs2/execute/Snippets.scala
@@ -135,9 +135,9 @@ case class SnippetParams[T](
 case class ScissorsCutter(cutMarker: String       = scissorsMarker,
                           cutMarkerFormat: String = scissorsMarkerFormat) extends (String => String) {
   def apply(text: String) = {
-    val splitted = text.split(cutMarkerFormat)
+    val split = text.split(cutMarkerFormat)
 
-    splitted.zipWithIndex.
+    split.zipWithIndex.
       collect { case (s, i) if i % 2 == 0 => s.removeStart("\n").removeEnd("\n") }.
       filter(_.trim.nonEmpty).mkString("\n")
   }

--- a/common/shared/src/main/scala/org/specs2/text/StringEditDistance.scala
+++ b/common/shared/src/main/scala/org/specs2/text/StringEditDistance.scala
@@ -24,7 +24,7 @@ trait StringEditDistance extends DiffShortener {
     })
 
   /**
-   * @param sep separators used to hightlight differences. If sep is empty, then no separator is used. If sep contains
+   * @param sep separators used to highlight differences. If sep is empty, then no separator is used. If sep contains
    * one character, it is taken as the unique separator. If sep contains 2 or more characters, the first half of the characters are taken as
    * opening separator and the second half as closing separator.
    *
@@ -68,10 +68,10 @@ trait StringEditDistance extends DiffShortener {
     shorten(fullResult, delimiter.first, delimiter.second, shortenSize)
   }
 
-  /** apply edit distance functions on strings splitted on newlines so that there are no memory issues */
+  /** apply edit distance functions on strings split on newlines so that there are no memory issues */
   def foldSplittedStrings[T](s1: String, s2: String, init: T, f: (T, String, String) => T): T = {
-    val (splitted1, splitted2) = split(s1, s2)
-    splitted1.zip(splitted2).foldLeft(init) { (result, current) =>
+    val (split1, split2) = split(s1, s2)
+    split1.zip(split2).foldLeft(init) { (result, current) =>
       f(result, current._1, current._2)
     }
   }
@@ -82,9 +82,9 @@ trait StringEditDistance extends DiffShortener {
    *  - otherwise split the strings so that they are less than 200 characters long
    */
   private def split(s1: String, s2: String): (List[String], List[String]) = {
-    val (splitted1, splitted2) = (s1.split("\n").toList, s2.split("\n").toList)
+    val (split1, split2) = (s1.split("\n").toList, s2.split("\n").toList)
     def splitToSize(strings: List[String]) = strings.flatMap(_.splitToSize(200))
-    (splitToSize(splitted1), splitToSize(splitted2))
+    (splitToSize(split1), splitToSize(split2))
   }
 
 
@@ -124,10 +124,10 @@ trait DiffShortener {
     def split(s: String, sep: String): Array[String] =
       if (List("[", "]" ,"(", ")", "-", "+", "?", "*").contains(sep)) split(s, "\\" + sep) else s.split(sep)
 
-    val splitted = split(s, firstSep)
-    if (splitted.size == 1) List(s)
+    val splitStr = split(s, firstSep)
+    if (splitStr.size == 1) List(s)
     else {
-      splitted.foldLeft(List[String]()) { (res, cur) =>
+      splitStr.foldLeft(List[String]()) { (res, cur) =>
         if (!cur.contains(secondSep)) res :+ cur
         else {
           lazy val diff = split(cur, secondSep)(0)

--- a/common/shared/src/main/scala/org/specs2/time/Timer.scala
+++ b/common/shared/src/main/scala/org/specs2/time/Timer.scala
@@ -82,7 +82,7 @@ trait HmsTimer[T <: HmsTimer[T]] {
   }
 
   /**
-   * this method can be overriden for testing
+   * this method can be overridden for testing
    */
   protected def getTime = new Date().getTime
 }

--- a/core/jvm/src/test/scala/org/specs2/specification/StoreSpec.scala
+++ b/core/jvm/src/test/scala/org/specs2/specification/StoreSpec.scala
@@ -12,7 +12,7 @@ class StoreSpec extends Specification { def is = sequential ^ s2"""
  The file store stores values in files where the name of the file is
    defined by the key $e1
 
- The store can be resetted $e2
+ The store can be reset $e2
 
 """
 

--- a/core/jvm/src/test/scala/org/specs2/text/StringEditDistanceSpec.scala
+++ b/core/jvm/src/test/scala/org/specs2/text/StringEditDistanceSpec.scala
@@ -39,7 +39,7 @@ class StringEditDistanceSpec extends Spec with StringEditDistance with DataTable
 
  The edit distance algorithm should
    not use too much memory on a big string comparison when working with file lines                        ${g4.e1}
-   dont use too much memory on a big string comparison on any type of string                              ${g4.e2}
+   not use too much memory on a big string comparison on any type of string                               ${g4.e2}
                                                                                                            """
 
   "edit distance" - new g1 {

--- a/core/shared/src/main/scala/org/specs2/runner/SbtRunner.scala
+++ b/core/shared/src/main/scala/org/specs2/runner/SbtRunner.scala
@@ -160,7 +160,7 @@ case class SbtTask(aTaskDef: TaskDef, env: Env, loader: ClassLoader) extends sbt
     Array()
   }
 
-  /** @return the correponding task definition */
+  /** @return the corresponding task definition */
   def taskDef = aTaskDef
 
   /** display errors and warnings */

--- a/core/shared/src/test/scala/org/specs2/text/SplitSpec.scala
+++ b/core/shared/src/test/scala/org/specs2/text/SplitSpec.scala
@@ -6,7 +6,7 @@ import matcher._
 
 class SplitSpec extends mutable.Spec with TypedEqual {
 
-  "a command line can be splitted" >> {
+  "a command line can be split" >> {
     "around spaces" >> {
       "this is hello world".splitQuoted === Seq("this", "is", "hello", "world")
     }

--- a/form/src/main/scala/org/specs2/form/Form.scala
+++ b/form/src/main/scala/org/specs2/form/Form.scala
@@ -27,7 +27,7 @@ class Form(val title: Option[String] = None, val rows: Seq[Row] = Vector(),  val
   /** @return the maximum cell size, column by column */
   lazy val maxSizes = allRows.map(_.cells).safeTranspose.map(l => l.map(_.width).max[Int])
 
-  /** @return a new Form. This method can be overriden to return a more accurate subtype */
+  /** @return a new Form. This method can be overridden to return a more accurate subtype */
   protected def newForm(title: Option[String] = None, rows: Seq[Row] = Vector(), result: Option[Result] = None) =
     new Form(title, rows, result)
   /** @return a Form where every Row is executed with a Success */

--- a/form/src/main/scala/org/specs2/form/FormsBuilder.scala
+++ b/form/src/main/scala/org/specs2/form/FormsBuilder.scala
@@ -26,7 +26,7 @@ trait FormsBuilder {
   implicit def fieldIsTextCell(t: Field[_]): FieldCell = new FieldCell(t)
   /** a Effect can be added on a Form row as a EffectCell */
   implicit def effectIsTextCell(t: Effect[_]): EffectCell = new EffectCell(t)
-  /** a Prop can be adde d on a Form row as a PropCell */
+  /** a Prop can be added on a Form row as a PropCell */
   implicit def propIsCell(t: Prop[_, _]): PropCell = new PropCell(t)
   /** a Form can be added on a Form row as a FormCell */
   implicit def formIsCell(t: =>Form): FormCell = new FormCell(t)

--- a/form/src/test/scala/org/specs2/form/PropSpec.scala
+++ b/form/src/test/scala/org/specs2/form/PropSpec.scala
@@ -12,7 +12,7 @@ class PropSpec extends script.Spec with Grouped with TypedEqual {  def is = s2""
                                                                     
 A Prop is a Field defining an expected and an actual value.
 
-It embeddeds an optional constraint which allows to execute the Prop and see (by default) if
+It embeds an optional constraint which allows to execute the Prop and see (by default) if
 the actual value is equal to the expected value.
 
 Creation

--- a/guide/src/test/scala/org/specs2/guide/PrintExecutionData.scala
+++ b/guide/src/test/scala/org/specs2/guide/PrintExecutionData.scala
@@ -35,7 +35,7 @@ trait Timed extends AroundEach {
     result.updateExpected("Execution time: "+timer.time)
   }
 
-  /** mesure the execution time of a piece of code */
+  /** measure the execution time of a piece of code */
   def withTimer[T](t: =>T): (T, SimpleTimer) = {
     val timer = (new SimpleTimer).start
     val result = t

--- a/gwt/src/test/scala/org/specs2/specification/StepParsersSpec.scala
+++ b/gwt/src/test/scala/org/specs2/specification/StepParsersSpec.scala
@@ -10,7 +10,7 @@ class StepParsersSpec extends Spec with Grouped with TypedEqual { def is = s2"""
 
  Delimited parsers can be used to extract values from specifications
 
- The defaul delimiters are `{}`
+ The default delimiters are `{}`
    one value can be extracted with a function with one argument                       ${g1.e1}
    two values can be extracted with a function with two arguments                     ${g1.e2}
    a sequence of values can be extracted with a function taking a Seq of values       ${g1.e3}

--- a/html/src/main/scala/org/specs2/html/Htmlx.scala
+++ b/html/src/main/scala/org/specs2/html/Htmlx.scala
@@ -154,9 +154,9 @@ trait Htmlx { outer =>
   /** @return the href urls in <a/> elements */
   def urls(ns: NodeSeq, filePath: FilePath = DirectoryPath.EMPTY.toFilePath): List[String] = {
     def decode(href: String) = {
-      val splitted = href.split("#").toSeq
-      val url    = filePath.dir / FilePath.unsafe(URLDecoder.decode(splitted(0), "UTF-8"))
-      val anchor = splitted.drop(1).lastOption.map(anchor => "#"+anchor).getOrElse("")
+      val split = href.split("#").toSeq
+      val url    = filePath.dir / FilePath.unsafe(URLDecoder.decode(split(0), "UTF-8"))
+      val anchor = split.drop(1).lastOption.map(anchor => "#"+anchor).getOrElse("")
       url.path + anchor
     }
     (ns \\ "a").flatMap(a => a.attribute("href").map(href => decode(href.mkString))).toList

--- a/matcher/shared/src/main/scala/org/specs2/matcher/NumericMatchers.scala
+++ b/matcher/shared/src/main/scala/org/specs2/matcher/NumericMatchers.scala
@@ -5,7 +5,7 @@ import text.Plural._
 import NumericMatchers._
 
 /**
-  * Matchers for Numerical values
+ * Matchers for Numerical values
  */
 trait NumericMatchers extends NumericBaseMatchers with NumericBeHaveMatchers {
   /** implicit definition to create delta for the beCloseTo matcher */

--- a/matcher/shared/src/main/scala/org/specs2/matcher/StandardMatchResults.scala
+++ b/matcher/shared/src/main/scala/org/specs2/matcher/StandardMatchResults.scala
@@ -4,7 +4,7 @@ package matcher
 import text.Sentences._
 
 /**
- * This trait can be used in conjonction with Pattern matchers:
+ * This trait can be used in conjunction with Pattern matchers:
  *
  * List(1, 2) must be like { case List(a, b) => ok }
  * List(1, 2) must be like { case List(a, b) => ko("unexpected") }

--- a/notes/1.7.1.markdown
+++ b/notes/1.7.1.markdown
@@ -1,6 +1,6 @@
 This version fixes an important issue from 1.7:
 
- * following the change in 1.7 which allowed results to be displayed as soon as computed on the console, there was no more guarantee that steps would execute stricly after the preceding group of examples
+ * following the change in 1.7 which allowed results to be displayed as soon as computed on the console, there was no more guarantee that steps would execute strictly after the preceding group of examples
    
 There are a few improvements:  
   

--- a/notes/1.9.markdown
+++ b/notes/1.9.markdown
@@ -16,7 +16,7 @@ This version adds new features on top of 1.8.2:
  * added a `stopOnSkip` argument to stop the execution of a specification after the first skipped value
  * added a `skipAllIf(condition)` argument to skip all the examples if a condition is verified
  * added a `checkUrl` argument to check that urls in the produced html files are indeed accessible
- * added a confliciting implicit with a method name explaining what is happening if an operator is forgotten for an `Example`. When trying to compile: `"this example won't work" { ko }`, the compiler will raise an implicit conflict error with including this message `***If you see this message this means that you've forgotten an operator after the description string: you should write "example" >> result ***`
+ * added a conflicting implicit with a method name explaining what is happening if an operator is forgotten for an `Example`. When trying to compile: `"this example won't work" { ko }`, the compiler will raise an implicit conflict error with including this message `***If you see this message this means that you've forgotten an operator after the description string: you should write "example" >> result ***`
  
 And some fixes:
 

--- a/tests/src/test/scala/org/specs2/matcher/AnyMatchersSpec.scala
+++ b/tests/src/test/scala/org/specs2/matcher/AnyMatchersSpec.scala
@@ -67,7 +67,7 @@ class AnyMatchersSpec extends script.Specification with Groups with ResultMatche
   ${ (null:String) must not be asNullAs(1) }
   ${ 1 must be asNullAs(1) }
 
-  beOneOf matches a value is amongs others
+  beOneOf checks if a value is amongst others
   ${ 1 must beOneOf(1, 2, 3) }
   ${ 4 must not be oneOf(1, 2, 3) }
 

--- a/tests/src/test/scala/org/specs2/matcher/describe/ComparisonResultSpec.scala
+++ b/tests/src/test/scala/org/specs2/matcher/describe/ComparisonResultSpec.scala
@@ -20,7 +20,7 @@ class ComparisonResultSpec extends Spec { def is = s2"""
   Seq render:
   ===========
 
-  identicate seq should print to string of the set                                        $seq1
+  identical seq should print to string of the set                                         $seq1
   different seq should print identical values first                                       $seq2
   different seq should print changed values first                                         $seq3
   different seq should print added values with prefix added: a                            $seq4
@@ -30,7 +30,7 @@ class ComparisonResultSpec extends Spec { def is = s2"""
   Array render:
   =============
 
-  identicate array should print to string of the set                                      $arr1
+  identical array should print to string of the set                                       $arr1
   different array should print identical values first                                     $arr2
   different array should print changed values first                                       $arr3
   different array should print added values with prefix added: a                          $arr4
@@ -41,7 +41,7 @@ class ComparisonResultSpec extends Spec { def is = s2"""
   Set render:
   ===========
 
-  identicate set should print to string of the set                                        $set1
+  identical set should print to string of the set                                         $set1
   different set should print identical values first                                       $set2
   different set should print added values with prefix added: a                            $set3
   different set should print removed values with prefix removed: b                        $set4
@@ -50,7 +50,7 @@ class ComparisonResultSpec extends Spec { def is = s2"""
   Map render:
   ===========
 
-  identicate map should print to string of the map                                        $m1
+  identical map should print to string of the map                                         $m1
   different map should print identical values first                                       $m2
   different map should print non identical values second in format: x -> { y != z }       $m3
   different map should print added values with prefix added: x -> y                       $m4

--- a/tests/src/test/scala/org/specs2/specification/process/StatsSpec.scala
+++ b/tests/src/test/scala/org/specs2/specification/process/StatsSpec.scala
@@ -12,7 +12,7 @@ import ExecuteActions._
 
 class StatsSpec(val env: Env) extends Specification with OwnEnv { def is = s2"""
 
- Statitistics can be computed for a stream of fragments
+ Statistics can be computed for a stream of fragments
   1 success            $e1
   1 success, 1 failure $e2
 


### PR DESCRIPTION
I ran a spell checker on the whole project and tried to fix as many typos as possible (I had a lot of false positives, so there might still be some typos in there).

Unfortunately, some typos cannot be changed without performing breaking changes, so I left those alone, namely:

* There's no word "splitted", the correct spelling is "split": (http://www.verbix.com/webverbix/English/split.html);
* It's Levenshtein, not Levenhstein (https://en.wikipedia.org/wiki/Levenshtein_distance).

I also did not change some words that I don't know how to spell (e.g. "uncamel case", "un-camel case", "un-camelcase"?)