### PR TITLE
Avoid unnecessary conversions

### DIFF
--- a/common/shared/src/main/scala/org/specs2/collection/Seqx.scala
+++ b/common/shared/src/main/scala/org/specs2/collection/Seqx.scala
@@ -70,7 +70,7 @@ trait Seqx { outer =>
       for (x <- seq)
         if (occurrences(D(x, equality)) == 0) result += x
         else                                  occurrences(D(x, equality)) -= 1
-      result.toSeq
+      result
     }
 
     private case class D(t: T, equality: (T, T) => Boolean) {

--- a/common/shared/src/main/scala/org/specs2/control/StackTraceFilter.scala
+++ b/common/shared/src/main/scala/org/specs2/control/StackTraceFilter.scala
@@ -87,7 +87,7 @@ object DefaultStackTraceFilter extends
   }
 
   private def truncated(size: Int): Seq[StackTraceElement] = {
-    def trace(message: String) = new StackTraceElement(message, " "*(70 - message.size), "", 0)
+    def trace(message: String) = new StackTraceElement(message, " "*(70 - message.length), "", 0)
     Seq(trace("="*70)) ++
     Seq.fill(10)(trace("...")) ++
     Seq(trace("....  TRUNCATED: the stacktrace is bigger than 1000 lines: "+size)) ++

--- a/common/shared/src/main/scala/org/specs2/data/Sized.scala
+++ b/common/shared/src/main/scala/org/specs2/data/Sized.scala
@@ -29,7 +29,7 @@ object Sized {
   }
   /** a regular string has a size, without having to be converted to an Traversable */
   implicit def stringIsSized: Sized[String] = new Sized[String] {
-    def size(t: String) = t.size
+    def size(t: String) = t.length
   }
 
 }

--- a/common/shared/src/main/scala/org/specs2/execute/Result.scala
+++ b/common/shared/src/main/scala/org/specs2/execute/Result.scala
@@ -378,7 +378,7 @@ case class Error(m: String, t: Throwable) extends Result(s"${t.getClass.getName}
 
   /** @return an exception created from the message and the stackTraceElements */
   def exception = t
-  def stackTrace = t.getFullStackTrace.toList
+  def stackTrace = t.getFullStackTrace
 
   override def equals(o: Any) = {
     o match {

--- a/common/shared/src/main/scala/org/specs2/main/Diffs.scala
+++ b/common/shared/src/main/scala/org/specs2/main/Diffs.scala
@@ -54,7 +54,7 @@ case class SmartDiffs(show: Boolean       = true,
 
   def showDiffs(actualValue: Any, expectedValue: Any) = {
     val (actual, expected) = (actualValue.notNull, expectedValue.notNull)
-    if (editDistance(actual, expected).doubleValue / (actual.size + expected.size) < diffRatio.doubleValue / 100)
+    if (editDistance(actual, expected).doubleValue / (actual.length + expected.length) < diffRatio.doubleValue / 100)
       showDistance(actual, expected, separators, shortenSize)
     else
       (actual, expected)

--- a/common/shared/src/main/scala/org/specs2/text/Interpolated.scala
+++ b/common/shared/src/main/scala/org/specs2/text/Interpolated.scala
@@ -11,12 +11,12 @@ class Interpolated(stringContent: String, texts: Seq[String]) extends Interpolat
 
   def expressions = {
     texts.zip(texts.drop(1)).foldLeft((stringContent, Seq[String]())) { case ((content, exps), (text, next)) =>
-      val minusText = new String(content.drop(text.size).mkString).
+      val minusText = new String(content.drop(text.length).mkString).
                         replace("$$", "$") // in next, this replacement has already been done
       val textToParse = new String(if (minusText.indexOf(next) > 0) minusText.substring(0, minusText.indexOf(next)) else minusText)
 
       val expression = interpolate(textToParse)
-      (new String(minusText.drop(expression.size)), exps :+ trimVariableDeclaration(expression))
+      (new String(minusText.drop(expression.length)), exps :+ trimVariableDeclaration(expression))
     }._2
   }
 

--- a/common/shared/src/main/scala/org/specs2/text/Quote.scala
+++ b/common/shared/src/main/scala/org/specs2/text/Quote.scala
@@ -26,7 +26,7 @@ trait Quote {
   /** quote a sequence, with commas if short, with newlines otherwise */
   def qseq(seq: GenTraversableOnce[_]): String = {
     val withCommas = q(seq.mkString(", "))
-    if (withCommas.size < 30) withCommas
+    if (withCommas.length < 30) withCommas
     else seq.mkString("\n", "\n  ", "\n")
   }
 

--- a/common/shared/src/main/scala/org/specs2/text/RegexExtractor.scala
+++ b/common/shared/src/main/scala/org/specs2/text/RegexExtractor.scala
@@ -66,7 +66,7 @@ object RegexExtractor {
   /** extract all groups and return a list of strings */
   def extractAll(text: String, full: =>Regex = "".r, group: =>Regex = DEFAULT_REGEX.r): List[String] = tryWithRegex(text, regexToUse(full, group)) {
     if (full.toString.isEmpty) group.findAllIn(text.trim).matchData.collect { case Regex.Groups(g) => g }.toList
-    else                       full.unapplySeq(text.trim).getOrElse(throw new FailureException(Failure(s"could not extract '$full' from $text"))).toList
+    else                       full.unapplySeq(text.trim).getOrElse(throw new FailureException(Failure(s"could not extract '$full' from $text")))
   }
 
   private def regexToUse(full: =>Regex, group: =>Regex) = if (full.toString.isEmpty) group else full

--- a/common/shared/src/main/scala/org/specs2/text/Split.scala
+++ b/common/shared/src/main/scala/org/specs2/text/Split.scala
@@ -16,7 +16,7 @@ trait Split { outer =>
     def splitToSize(n: Int): List[String] = splitToSize(s, n, Nil)
 
     private def splitToSize(string: String, n: Int, result: List[String]): List[String] = {
-      if (string.size <= n) (string :: result).reverse
+      if (string.length <= n) (string :: result).reverse
       else
       // new Strings are necessary to avoid memory errors because substring is just a view on the underlying string
         splitToSize(new String(string.drop(n)), n, new String(string.take(n)) :: result)

--- a/common/shared/src/main/scala/org/specs2/text/TextTable.scala
+++ b/common/shared/src/main/scala/org/specs2/text/TextTable.scala
@@ -32,7 +32,7 @@ case class TextTable(header: Seq[String], lines: Seq[Seq[String]], separator: St
 
   /** @return the seq of maximum size of each column */
   private def maximumsByColumn(lines: Seq[Seq[String]]): Seq[Int] =
-    transpose(lines).map(column => column.map(_.size).max)
+    transpose(lines).map(column => column.map(_.length).max)
 
 }
 

--- a/common/shared/src/main/scala/org/specs2/text/Trim.scala
+++ b/common/shared/src/main/scala/org/specs2/text/Trim.scala
@@ -22,10 +22,10 @@ trait Trim {
   case class Trimmed(s: String) {
 
     def trimStart(start: String) =
-      if (s.trim.startsWith(start)) s.trim.drop(start.size) else s.trim
+      if (s.trim.startsWith(start)) s.trim.drop(start.length) else s.trim
 
     def trimEnd(end: String) =
-      if (s.trim.endsWith(end)) s.trim.dropRight(end.size)  else s.trim
+      if (s.trim.endsWith(end)) s.trim.dropRight(end.length)  else s.trim
 
     def trimEndSpace =
       s.takeWhile(_ == ' ') + s.trim
@@ -39,10 +39,10 @@ trait Trim {
     def trimEnclosingXmlTag(t: String) = trimFirst("<"+t+".*?>").trimEnd("</"+t+">")
 
     def removeStart(start: String) =
-      if (s.startsWith(start)) s.drop(start.size) else s
+      if (s.startsWith(start)) s.drop(start.length) else s
 
     def removeEnd(end: String) =
-      if (s.endsWith(end)) s.dropRight(end.size)  else s
+      if (s.endsWith(end)) s.dropRight(end.length)  else s
 
     def removeEnclosing(toRemove: String):String = removeEnclosing(toRemove, toRemove)
 
@@ -73,7 +73,7 @@ trait Trim {
       if (matches.isEmpty) s
       else {
         val last = matches.last
-        s.substring(0, last.start) + s.substring(last.end, s.size)
+        s.substring(0, last.start) + s.substring(last.end, s.length)
       }
     }
 
@@ -142,7 +142,7 @@ trait Trim {
 
     /** truncate a string to a given number of characters and ellide the missing characters with ... */
     def truncate(length: Int): String =
-      if (s.size > length) s.take(length - 3)+"..."
+      if (s.length > length) s.take(length - 3)+"..."
       else s
   }
 

--- a/common/shared/src/main/scala/org/specs2/xml/NodeFunctions.scala
+++ b/common/shared/src/main/scala/org/specs2/xml/NodeFunctions.scala
@@ -34,7 +34,7 @@ trait NodeFunctions {
    * @return true if two Nodes are equal without considering spaces
    */
   def isEqualIgnoringSpace(node: NodeSeq, n: NodeSeq): Boolean = {
-    def sameAs(nodes1: NodeSeq, nodes2: NodeSeq) = nodes1.toList.sameElementsAs(nodes2.toSeq, isEqualIgnoringSpace)
+    def sameAs(nodes1: NodeSeq, nodes2: NodeSeq) = nodes1.toList.sameElementsAs(nodes2, isEqualIgnoringSpace)
     isEqualIgnoringSpace(node, n, sameAs)
   }
 

--- a/common/shared/src/test/scala/org/specs2/collection/SeqGenerators.scala
+++ b/common/shared/src/test/scala/org/specs2/collection/SeqGenerators.scala
@@ -16,7 +16,7 @@ trait SeqGenerators {
       }
     }
     for {
-      indices <- Gen.someOf((0 until ts.size).toSeq)
+      indices <- Gen.someOf((0 until ts.size))
     } yield slice(indices.sorted)
   }
 

--- a/core/jvm/src/test/scala/org/specs2/control/ThrowablexSpec.scala
+++ b/core/jvm/src/test/scala/org/specs2/control/ThrowablexSpec.scala
@@ -29,7 +29,7 @@ The Throwablex trait provides extensions to regular throwables:
 
   "chained" - new group with ThrowablexContext {
     eg := e.chainedExceptions      === List(e.getCause)
-    eg := e.getFullStackTrace.size === e.getStackTrace.size + e.getCause.getStackTrace.size
+    eg := e.getFullStackTrace.size === e.getStackTrace.length + e.getCause.getStackTrace.length
     eg := e.messageAndCause        === "message. Cause: cause"
   }
   "location" - new group with ThrowablexContext {

--- a/core/jvm/src/test/scala/org/specs2/specification/AllExpectationsSpec.scala
+++ b/core/jvm/src/test/scala/org/specs2/specification/AllExpectationsSpec.scala
@@ -23,11 +23,11 @@ class AllExpectationsSpec(val env: Env) extends Spec with AllExpectations with O
                                       "1 != 3 [AllExpectationsSpecification.scala:9]"
     }
     "short-circuit the rest of the example if an expectation fails and uses 'orThrow'" >> {
-      executedIssues.map(_.message).toList must containMatch("51 != 52")
+      executedIssues.map(_.message) must containMatch("51 != 52")
       executedIssues.map(_.message) must not containMatch("13 != 14")
     }
     "short-circuit the rest of the example if an expectation fails and uses 'orSkip'" >> {
-      executedSuspended.map(_.message).toList must not containMatch("'51' is not equal to '52'")
+      executedSuspended.map(_.message) must not containMatch("'51' is not equal to '52'")
       executedIssues.map(_.message) must not containMatch("'15' is not equal to '16'")
     }
     "work ok on a specification with selected fragments" >> {

--- a/core/jvm/src/test/scala/org/specs2/specification/S2StringContextSpec.scala
+++ b/core/jvm/src/test/scala/org/specs2/specification/S2StringContextSpec.scala
@@ -81,7 +81,7 @@ Intro
 	test2 $ok
 """.fragmentsList(ee)
 
-      fragments.map(_.description.show.replace(" ", "-").replace("\n", "*")).toList ====
+      fragments.map(_.description.show.replace(" ", "-").replace("\n", "*")) ====
         List("*Intro*--", "test1", "*--", "test2")
     }
 

--- a/core/jvm/src/test/scala/org/specs2/specification/SelectorSpec.scala
+++ b/core/jvm/src/test/scala/org/specs2/specification/SelectorSpec.scala
@@ -128,7 +128,7 @@ class SelectorSpec(ee: ExecutionEnv) extends script.Specification with Groups wi
       )
       checkSelection(fragments, "x",           expected = Seq("e2", "e3", "e4", "e5", "e6"), unexpected = Seq("e1", "e7", "e8", "e9")) and
       checkSelection(fragments, "x&&y",        expected = Seq("e4", "e5", "e6"),             unexpected = Seq("e1", "e2", "e3", "e7", "e8", "e9")) and
-      checkSelection(fragments, Seq("x", "y"), expected = (2 to 8).map("e"+_).toSeq,         unexpected = Seq("e1", "e9"))
+      checkSelection(fragments, Seq("x", "y"), expected = (2 to 8).map("e" + _),             unexpected = Seq("e1", "e9"))
     }
 
     eg := {

--- a/core/jvm/src/test/scala/org/specs2/specification/core/FragmentsSpec.scala
+++ b/core/jvm/src/test/scala/org/specs2/specification/core/FragmentsSpec.scala
@@ -26,6 +26,6 @@ class FragmentsSpec(ee: ExecutionEnv) extends Spec with Tables with TypedEqual {
     "e(e1), t(a1), t(a2)"        ! Seq("e1", "a1a2")                   |
     "e(e1), t(a1), t(a2), e(e2)" ! Seq("e1", "a1a2", "e2")             |
     "e(e1), t(a1), e(e2), t(a2)" ! Seq("e1", "a1", "e2", "a2")         |
-    { (fs, r) => Fragments(fs.split(",").map(toFragment):_*).compact.fragmentsList(ee).map(_.description.show).toList === r }
+    { (fs, r) => Fragments(fs.split(",").map(toFragment): _*).compact.fragmentsList(ee).map(_.description.show) === r }
   }
 }

--- a/core/jvm/src/test/scala/org/specs2/text/StringEditDistanceSpec.scala
+++ b/core/jvm/src/test/scala/org/specs2/text/StringEditDistanceSpec.scala
@@ -99,11 +99,11 @@ class StringEditDistanceSpec extends Spec with StringEditDistance with DataTable
     val factor = 1000
     e1 := {
       (editDistance("kitten\n" * factor, "kitsin\n" * factor) must be_>(0)) and
-      (showDistance("kitten\n" * factor, "kitsin\n" * factor)._1.size must be_>(0))
+      (showDistance("kitten\n" * factor, "kitsin\n" * factor)._1.length must be_>(0))
     }
     e2 := {
       (editDistance("kitten" * factor, "kitsin" * factor) must be_>(0)) and
-      (showDistance("kitten" * factor, "kitsin" * factor)._1.size must be_>(0))
+      (showDistance("kitten" * factor, "kitsin" * factor)._1.length must be_>(0))
     }
   }
 }

--- a/core/shared/src/main/scala/org/specs2/reporter/TextPrinter.scala
+++ b/core/shared/src/main/scala/org/specs2/reporter/TextPrinter.scala
@@ -272,7 +272,7 @@ trait TextPrinter extends Printer {
 
   /** print a short summary of differences between Seqs, Sets or Maps */
   def printSummary(descriptions: (String, Seq[String])*) =
-    if (descriptions.flatMap(_._2).mkString("\n").split("\n").size >= 50)
+    if (descriptions.flatMap(_._2).mkString("\n").split("\n").length >= 50)
       List((descriptions.map { case (name, values) => s"$name = ${values.size}" }.mkString(", ")).failure)
     else Nil
 

--- a/core/shared/src/main/scala/org/specs2/runner/SpecificationsFinder.scala
+++ b/core/shared/src/main/scala/org/specs2/runner/SpecificationsFinder.scala
@@ -81,7 +81,7 @@ trait SpecificationsFinder {
       objectPattern <- specObjectPattern
       classPattern  <- specClassPattern
       paths         <- filePathReader.filePaths(basePath, pathGlob, verbose)
-    } yield paths.toList.map(path => readClassNames(path, objectPattern, classPattern, filePathReader, verbose)).sequence.map(_.flatten)
+    } yield paths.map(path => readClassNames(path, objectPattern, classPattern, filePathReader, verbose)).sequence.map(_.flatten)
   }.flatMap[List[String]](identity)
 
   /**

--- a/core/shared/src/main/scala/org/specs2/specification/create/S2Macro.scala
+++ b/core/shared/src/main/scala/org/specs2/specification/create/S2Macro.scala
@@ -15,7 +15,7 @@ object S2Macro {
     val fileContent = macroPos.source.content.mkString
 
     def contentFrom(pos: c.Position) = fileContent.split("\n").drop(pos.line - 1).mkString("\n").drop(pos.column-1)
-    val content = contentFrom(macroPos).drop("s2\"\"\"".size)
+    val content = contentFrom(macroPos).drop("s2\"\"\"".length)
     val Yrangepos = macroPos.isRange
 
     def traceLocation(pos: c.universe.Position): String =

--- a/core/shared/src/test/scala/org/specs2/data/TreesSpec.scala
+++ b/core/shared/src/test/scala/org/specs2/data/TreesSpec.scala
@@ -61,7 +61,7 @@ class TreesSpec extends script.Specification with DataTables with Grouped with E
 
     eg := {
       val tree = tree3.loc.addChild(4).tree
-      tree.flattenLeft.toSeq aka "flattenLeft" must_== tree.flatten.toSeq
+      tree.flattenLeft aka "flattenLeft" must_== tree.flatten
     }
   }
 

--- a/core/shared/src/test/scala/org/specs2/text/TrimSpec.scala
+++ b/core/shared/src/test/scala/org/specs2/text/TrimSpec.scala
@@ -39,9 +39,9 @@ class TrimSpec extends Specification { def is = s2"""
   ${eg{ "hello\n\r world".removeNewLines === "hello world" }}
 
   Split and trim
-  ${eg{ "a,b,c".splitTrim(",").toSeq === Seq("a", "b", "c") }}
-  ${eg{ "a, b , c".splitTrim(",").toSeq === Seq("a", "b", "c") }}
-  ${eg{ "a,  ,c".splitTrim(",").toSeq === Seq("a", "c") }}
+  ${eg{ "a,b,c".splitTrim(",") === Seq("a", "b", "c") }}
+  ${eg{ "a, b , c".splitTrim(",") === Seq("a", "b", "c") }}
+  ${eg{ "a,  ,c".splitTrim(",") === Seq("a", "c") }}
 
   Start from trims the string of everything that is before the start substring
     if the string starts with the specified substring

--- a/examples/jvm/src/test/scala/examples/HelloWorldUnitAllExpectationsSpec.scala
+++ b/examples/jvm/src/test/scala/examples/HelloWorldUnitAllExpectationsSpec.scala
@@ -10,7 +10,7 @@ class HelloWorldUnitAllExpectationsSpec extends mutable.Specification with AllEx
 
     "Hello world" >> {
       "Hello world".reverse === "dlrow olleH"
-      "Hello world".size === 11
+      "Hello world".length === 11
       "Hello world".split("\\s") must haveSize(2)
       "Hello world".toLowerCase === "hello world"
     }

--- a/form/src/main/scala/org/specs2/form/Cells.scala
+++ b/form/src/main/scala/org/specs2/form/Cells.scala
@@ -37,7 +37,7 @@ trait Text {
   def text: String
 
   /** @return the width of the cell, without borders when it's a FormCell */
-  def width: Int = text.size
+  def width: Int = text.length
 }
 /**
  * Base type for anything returning some xml
@@ -194,7 +194,7 @@ class FormCell(_form: =>Form, result: Option[Result] = None) extends Cell {
    * @return the width of a form when inlined.
    *         It is the width of its text size minus 4, which is the size of the borders "| " and " |"
    */
-  override def width = text.split("\n").map((_:String).size).max[Int] - 4
+  override def width = text.split("\n").map((_: String).length).max[Int] - 4
 }
 object FormCell {
   def unapply(cell: FormCell): Option[Form] = Some(cell.form)

--- a/guide/src/test/scala/org/specs2/guide/Matchers.scala
+++ b/guide/src/test/scala/org/specs2/guide/Matchers.scala
@@ -74,13 +74,13 @@ The easiest way to create a new matcher is to derive it from an existing one. Yo
  * "adapt" the actual value ${snippet {
 
 // This matcher adapts the existing `be_<=` matcher to a matcher applicable to `Any`
-def beShort1 = be_<=(5) ^^ { (t: Any) => t.toString.size }
+def beShort1 = be_<=(5) ^^ { (t: Any) => t.toString.length }
 
 // you can use aka to provide some information about the original value, before adaptation
-def beShort2 = be_<=(5) ^^ { (t: Any) => t.toString.size aka "the string size" }
+def beShort2 = be_<=(5) ^^ { (t: Any) => t.toString.length aka "the string size" }
 
 // !!! note: use a BeTypedEqualTo matcher when using aka and equality, otherwise you will be matching against Expectable[T] !!!
-def beFive = be_===(5) ^^ { (t: Any) => t.toString.size aka "the string size" }
+def beFive = be_===(5) ^^ { (t: Any) => t.toString.length aka "the string size" }
 
 // The adaptation can also be done the other way around when it's more readable
 def haveExtension(extension: =>String) = ((_:File).getPath) ^^ endWith(extension)

--- a/html/src/main/scala/org/specs2/html/TableOfContents.scala
+++ b/html/src/main/scala/org/specs2/html/TableOfContents.scala
@@ -102,10 +102,10 @@ trait TableOfContents {
         s.reduceNodes.updateHeadAttribute("id", page.path.name.name)
       else if (h.level > 1)
         <li><a href={page.relativePath.path+"#"+h.pandocName} title={h.name}>{h.name.truncate(entryMaxSize)}</a>
-          { <ul>{s.toSeq}</ul> unless s.isEmpty }
+          { <ul>{s}</ul> unless s.isEmpty }
         </li>
       else
-        <ul>{s.toSeq}</ul> unless s.isEmpty
+        <ul>{s}</ul> unless s.isEmpty
 
     }.rootLabel
   }

--- a/html/src/main/scala/org/specs2/reporter/HtmlBodyPrinter.scala
+++ b/html/src/main/scala/org/specs2/reporter/HtmlBodyPrinter.scala
@@ -176,8 +176,8 @@ trait HtmlBodyPrinter {
 
       case FailureSetDetails(expected, actual) if arguments.diffs.showSeq(expected.toSeq, actual.toSeq, ordered = false) =>
         val (added, missing) = arguments.diffs.showSeqDiffs(actual.toSeq, expected.toSeq, ordered = true)
-        val addedValues   = makeDifferencesMessage("Added", added.toSeq)
-        val missingValues = makeDifferencesMessage("Missing", missing.toSeq)
+        val addedValues   = makeDifferencesMessage("Added", added)
+        val missingValues = makeDifferencesMessage("Missing", missing)
         val details = List(addedValues, missingValues).mkString("\n")
 
         <details class="failure">{details}</details>

--- a/junit/shared/src/main/scala/org/specs2/reporter/JUnitPrinter.scala
+++ b/junit/shared/src/main/scala/org/specs2/reporter/JUnitPrinter.scala
@@ -111,7 +111,7 @@ trait JUnitPrinter extends Printer { outer =>
       val details =
         if (args.diffs.showSeq(actual.toSeq, expected.toSeq, ordered = false)) {
           val (added, missing) = args.diffs.showSeqDiffs(actual.toSeq, expected.toSeq, ordered = false)
-          List(showValues("Added", added.toSeq), showValues("Missing", missing.toSeq)).mkString(" / ")
+          List(showValues("Added", added), showValues("Missing", missing)).mkString(" / ")
         } else ""
 
       new ComparisonFailure(AnsiColors.removeColors(m+details), expected.mkString("\n"), actual.mkString("\n")) {

--- a/markdown/src/main/scala/org/specs2/text/Markdown.scala
+++ b/markdown/src/main/scala/org/specs2/text/Markdown.scala
@@ -77,14 +77,14 @@ case class Specs2Visitor(text: String, options: MarkdownOptions = MarkdownOption
   override def visit(node: SimpleNode) {
     super.visit(node)
     if (node.getType == SimpleNode.Type.Linebreak) {
-      val indent = text.drop(node.getEndIndex).takeWhile(_ == ' ').size
+      val indent = text.drop(node.getEndIndex).takeWhile(_ == ' ').length
       (1 to indent) foreach { i => super.visit(new SimpleNode(SimpleNode.Type.Nbsp)) }
     }
   }
   override def visit(node: VerbatimNode) {
     // render verbatim nodes as simple text if the verbatim option is false
     if (!options.verbatim && node.getType.isEmpty && node.getText.contains("\n")) {
-      val indents = text.split("\n").filter(_.nonEmpty).map(line => line.takeWhile(_==' ').size)
+      val indents = text.split("\n").filter(_.nonEmpty).map(line => line.takeWhile(_ == ' ').length)
       val verbatim = node.getText.split("\n").map(line => line.trim)
       val lines = (indents zip verbatim).map { case (indent, line) => "&nbsp;"*indent + line }.mkString("<br/>")
       super.visit(new TextNode(lines))

--- a/matcher/shared/src/main/scala/org/specs2/matcher/TraversableMatchers.scala
+++ b/matcher/shared/src/main/scala/org/specs2/matcher/TraversableMatchers.scala
@@ -56,14 +56,14 @@ trait TraversableBaseMatchers { outer =>
   /** match if traversable contains (x matches .*+t+.*) */
   def containMatch[T](t: =>String) = containPattern[T](t.regexPart)
   /** match if traversable contains (x matches p) */
-  def containPattern[T](t: =>String) = ContainWithResult(matcherIsValueCheck(new BeMatching(t))) ^^ ((ts: GenTraversableOnce[T]) => ts.toSeq.map(_.toString).to[GenTraversableOnce])
+  def containPattern[T](t: =>String) = ContainWithResult(matcherIsValueCheck(new BeMatching(t))) ^^ ((ts: GenTraversableOnce[T]) => ts.toSeq.map(_.toString))
 
   /** does a containAll comparison in both ways */
   def containTheSameElementsAs[T](seq: Seq[T], equality: (T, T) => Boolean = (_:T) == (_:T)): Matcher[Traversable[T]] = new Matcher[Traversable[T]] {
 
     def apply[S <: Traversable[T]](t: Expectable[S]) = {
-      val missing = seq.toSeq.difference(t.value.toSeq, equality)
-      val added   = t.value.toSeq.difference(seq.toSeq, equality)
+      val missing = seq.difference(t.value.toSeq, equality)
+      val added   = t.value.toSeq.difference(seq, equality)
       def message(diffs: Seq[_], msg: String) =
         if (diffs.isEmpty) "" else diffs.mkString("\n  "+msg+": ", ", ", "")
 

--- a/matcher/shared/src/main/scala/org/specs2/matcher/describe/ComparisonResult.scala
+++ b/matcher/shared/src/main/scala/org/specs2/matcher/describe/ComparisonResult.scala
@@ -203,7 +203,7 @@ case class CaseClassDifferent(className: String,
     renderProperty(indent)(change)
 
   private def renderProperty(indent: String)(r: CaseClassPropertyComparison): String =
-    r.result.render(indent + " " * (r.fieldName.size + 2)).tagWith(r.fieldName)
+    r.result.render(indent + " " * (r.fieldName.length + 2)).tagWith(r.fieldName)
 }
 
 case class OtherIdentical(actual: Any) extends IdenticalComparisonResult {
@@ -249,7 +249,7 @@ abstract class UnorderedCollectionDifferent[Element, Change](same:    Seq[Elemen
     render("")
 
   override def render(indent: String): String = {
-    val newIndent = indent+ " " * (className.size + 1)
+    val newIndent = indent+ " " * (className.length + 1)
 
     Seq(renderIdentical(newIndent) ++ renderChanged(newIndent) ++ renderAdded(newIndent) ++ renderRemoved(newIndent))
       .flatten.mkString("", ",\n"+newIndent, "").wrapWith(className)
@@ -280,7 +280,7 @@ abstract class OrderedCollectionDifferent[Element](results: Seq[ComparisonResult
     render("")
 
   override def render(indent: String): String = {
-    val newIndent = indent + " " * (className.size + 1)
+    val newIndent = indent + " " * (className.length + 1)
 
     Seq(renderResult(newIndent) ++ renderAdded(newIndent) ++ renderRemoved(newIndent))
       .flatten.mkString("", ",\n"+newIndent, "").wrapWith(className)

--- a/mock/jvm/src/test/scala/org/specs2/mock/MockitoSpec.scala
+++ b/mock/jvm/src/test/scala/org/specs2/mock/MockitoSpec.scala
@@ -485,7 +485,7 @@ ${step(env)}                                                                    
     }
 
     eg := {
-      list.size answers { m => m.toString.size}
+      list.size answers { m => m.toString.length}
       list.size must_== 4
     }
     eg := {

--- a/tests/src/test/scala/org/specs2/matcher/MatcherSpec.scala
+++ b/tests/src/test/scala/org/specs2/matcher/MatcherSpec.scala
@@ -62,11 +62,11 @@ Messages
     }
 
     eg := {
-      val result = new Exception("message")  must be_>(2) ^^ ((e:Exception) => e.getMessage.size aka "the message size")
+      val result = new Exception("message")  must be_>(2) ^^ ((e:Exception) => e.getMessage.length aka "the message size")
       result.message must_== "the message size '7' is greater than 2"
     }
     eg := {
-      val result = new Exception("message")  must be_===(8) ^^ ((e:Exception) => e.getMessage.size aka "the message size")
+      val result = new Exception("message")  must be_===(8) ^^ ((e:Exception) => e.getMessage.length aka "the message size")
       result.message must_=== "the message size '7 != 8'"
     }
     eg := {

--- a/tests/src/test/scala/org/specs2/matcher/TraversableMatchersSpec.scala
+++ b/tests/src/test/scala/org/specs2/matcher/TraversableMatchersSpec.scala
@@ -31,7 +31,7 @@ class TraversableMatchersSpec(val env: Env) extends Spec with ResultMatchers wit
    ${ Seq(1, 2) must contain(anyOf(1, 4)) }
    ${ (Seq(1, 2, 3) must not(contain(anyOf(1, 2, 4)))) returns "There are 2 successes\n'1' is contained in '1, 2, 4'\n'2' is contained in '1, 2, 4'\n" }
    ${ Seq("hello", "world") must contain(matching(".*orld")) }
-   ${ Seq("hello", "world") must contain((s: String) => s.size > 2) }
+   ${ Seq("hello", "world") must contain((s: String) => s.length > 2) }
    ${ Seq("1", "2", "3") must contain("3") and contain("2":Any) }
    ${ Seq("foobar").must(contain("foo")).not } see #416
    ${ Seq[Food](Pizza(), new Fruit()) must contain(Pizza()) }

--- a/tests/src/test/scala/org/specs2/specification/process/IndentationSpec.scala
+++ b/tests/src/test/scala/org/specs2/specification/process/IndentationSpec.scala
@@ -27,12 +27,12 @@ class IndentationSpec(implicit ee: ExecutionEnv) extends Specification with Scal
   }
 
   def lessThanOrEqualTabs = prop { fs: Fragments =>
-    val tabsNumber = fs.fragmentsList(ee).collect { case Fragment(Tab(n),_,_) => n }.toList.sumAll
+    val tabsNumber = fs.fragmentsList(ee).collect { case Fragment(Tab(n), _, _) => n }.sumAll
     indentation(fs) must beSome(be_<=(tabsNumber))
   }
 
   def equalTabsWhenNoBacktabs = prop { fs: Fragments =>
-    val tabsNumber = fs.fragmentsList(ee).collect { case Fragment(Tab(n),_,_) => n }.toList.sumAll
+    val tabsNumber = fs.fragmentsList(ee).collect { case Fragment(Tab(n), _, _) => n }.sumAll
     indentation(fs.filter(!isBacktab(_))) must beSome(tabsNumber)
   }
 


### PR DESCRIPTION
Avoid unnecessary collection conversions (e.g. `List(1,2,3).toList`).

I made this changes mostly because I had already executed IntelliJ's code analysis to find the typos in #605, so I might as well send some fixes.

This analysis shows a lot of warnings. While most of them are a matter of style/personal preference, there are some warnings there that might make sense to address. If you have the time, I think you should run it and see the results.