### PR TITLE
specify charset when writing files

### DIFF
--- a/common/shared/src/main/scala/org/specs2/io/FileSystem.scala
+++ b/common/shared/src/main/scala/org/specs2/io/FileSystem.scala
@@ -32,7 +32,7 @@ trait FileSystem extends FilePathReader {
   /** write a string to a file as UTF-8 */
   def writeFile(filePath: FilePath, content: String): Operation[Unit] =
     mkdirs(filePath) >>
-    Operations.protect { new PrintWriter(filePath.path) { try write(content) finally close }; () }
+    Operations.protect { new PrintWriter(filePath.path, "UTF-8") { try write(content) finally close }; () }
 
   /** execute an operation with a File, then delete it */
   def withEphemeralFile(path: FilePath)(operation: Operation[Unit]): Operation[Unit] =


### PR DESCRIPTION
The method comment promises to write the file using the UTF-8 charset, but the file is actually written using the platform default charset (which is not UTF-8 on Windows). This causes HTML reports (that use UTF-8 as hardcoded charset in their header) to contain illegal characters.
The proposed fix looks relatively non-contentious to me.