### PR TITLE
handle Win file paths like *nix paths

### DIFF
--- a/common/shared/src/main/scala/org/specs2/io/DirectoryPath.scala
+++ b/common/shared/src/main/scala/org/specs2/io/DirectoryPath.scala
@@ -30,10 +30,10 @@ case class DirectoryPath(dirs: Vector[FileName], absolute: Boolean) {
     }
 
   /** @return the path for this file as a / separated string */
-  def path: String = (if (absolute) File.separator else "") + dirs.map(_.name).toList.mkString(File.separator)
+  def path: String = (if (absolute) "/" else "") + dirs.map(_.name).toList.mkString("/")
 
   /** @return the path for this file as a / separated string, with a final / */
-  def dirPath: String = if (isRoot) path else path+File.separator
+  def dirPath: String = if (isRoot) path else path + "/"
 
   /** @return a File for this path */
   def toFile: File = new File(path)
@@ -108,9 +108,9 @@ object DirectoryPath {
   def apply(uuid: UUID): DirectoryPath = apply(FileName(uuid))
 
   def unsafe(s: String): DirectoryPath = {
-    val withoutScheme = removeScheme(s)
-    val isAbsolute = withoutScheme.startsWith(File.separator)
-    DirectoryPath(withoutScheme.split(s"\\Q${File.separator}\\E").filter(_.nonEmpty).map(FileName.unsafe).toVector, isAbsolute)
+    val withoutScheme = removeScheme(if (isWindows) s.replaceAll("\\\\", "/") else s)
+    val isAbsolute = withoutScheme.startsWith("/") || isWindows && new File(withoutScheme).isAbsolute
+    DirectoryPath(withoutScheme.split("/").filter(_.nonEmpty).map(FileName.unsafe).toVector, isAbsolute)
   }
 
   def unsafe(f: File): DirectoryPath = unsafe(f.getPath)
@@ -133,7 +133,7 @@ case class FilePath(dir: DirectoryPath, name: FileName) {
   def root: DirectoryPath = dir.root
 
   /** @return the path for this file as a / separated string */
-  def path: String = if (dir.isRoot) name.name else dir.path+File.separator+name.name
+  def path: String = if (dir.isRoot) name.name else dir.path + "/" + name.name
 
   /** @return a File for this path */
   def toFile: File = new File(path)

--- a/common/shared/src/main/scala/org/specs2/io/FileSystem.scala
+++ b/common/shared/src/main/scala/org/specs2/io/FileSystem.scala
@@ -32,7 +32,7 @@ trait FileSystem extends FilePathReader {
   /** write a string to a file as UTF-8 */
   def writeFile(filePath: FilePath, content: String): Operation[Unit] =
     mkdirs(filePath) >>
-    Operations.protect { new PrintWriter(filePath.path) { try write(content) finally close }; () }
+    Operations.protect { new PrintWriter(filePath.path, "UTF-8") { try write(content) finally close }; () }
 
   /** execute an operation with a File, then delete it */
   def withEphemeralFile(path: FilePath)(operation: Operation[Unit]): Operation[Unit] =

--- a/common/shared/src/main/scala/org/specs2/io/package.scala
+++ b/common/shared/src/main/scala/org/specs2/io/package.scala
@@ -24,8 +24,8 @@ package object io {
    * create a file name from a String
    */
   def fileNameFromString(s: String): Option[FileName] =
-    if (s.contains(File.separator)) None
-    else                            Some(FileName.unsafe(s))
+    if (s.contains(File.separator) || isWindows && s.contains("/")) None
+    else Some(FileName.unsafe(s))
 
   def createFileName(c: Context)(s: c.Expr[String]): c.Expr[FileName] = {
     import c.universe._
@@ -34,6 +34,8 @@ package object io {
       case _ => c.abort(c.enclosingPosition, s"Not a literal ${showRaw(s)}")
     }
   }
+
+  val isWindows = sys.props("os.name").startsWith("Windows")
 
   private def createFileNameFromString(c: Context)(s: String): c.Expr[FileName] = {
     import c.universe._


### PR DESCRIPTION
see my comments on https://github.com/etorreborre/specs2/commit/efccac81c4784fb19cc081ff37fd2958f1c2f79d

I've tested my "solution" on Windows. While it works mostly fine, it most probably will not handle all corner cases correctly either. For a correct solution, URIs and file paths must be treated differently. Sadly, even the file system API in the Java stdlib handles some file path cases incorrectly. At the very least, this improves compatibility with Win systems noticeably.

You might want to test if everything still works fine on *nix / Mac.

Hope this helps.