### PR TITLE
JUnit Descriptions must have a unique id

### DIFF
--- a/junit/jvm/src/test/scala/org/specs2/reporter/JUnitDescriptionSpec.scala
+++ b/junit/jvm/src/test/scala/org/specs2/reporter/JUnitDescriptionSpec.scala
@@ -27,6 +27,7 @@ class JUnitDescriptionSpec(val env: Env) extends Specification with JUnitDescrip
    An example description must not have newlines if executed from an IDE                                            $a8
    Empty descriptions must be removed from the tree                                                                 $a9
    Examples with the same name must get different ids                                                               $a10
+   Examples with the same location (e.g. Fragments.foreach) must get different ids                                  $a11
 
  The Descriptions objects must have proper details
    For as single Example                                                                                            $b1
@@ -135,6 +136,18 @@ class JUnitDescriptionSpec(val env: Env) extends Specification with JUnitDescrip
       ShowDescription.toTree(descriptions(false).
         createDescription(titled(start ^ "level1" ^ break ^ ex1fst ^ ex1snd ^ end))(ee)).flatten.toList
 
+    ds.map(_.hashCode).distinct must haveSize(4)
+  }
+
+  def a11 = {
+    val fs =
+      Fragments.foreach(Seq("ex1", "ex2", "ex3")) { _ => success }
+
+    val ds =
+      ShowDescription.toTree(descriptions(false).
+        createDescription(fs)(ee)).flatten.toList
+
+    // header + 3 examples
     ds.map(_.hashCode).distinct must haveSize(4)
   }
 

--- a/junit/shared/src/main/scala/org/specs2/reporter/JUnitDescriptions.scala
+++ b/junit/shared/src/main/scala/org/specs2/reporter/JUnitDescriptions.scala
@@ -52,7 +52,7 @@ trait JUnitDescriptions extends ExecutionOrigin {
           case f @ Fragment(d, e, _) if !e.isExecutable => createDescription(className, suiteName = testName(d.show), annotations = annotations)
           case f @ Fragment(NoText, e, _) if e.mustJoin => createDescription(className, label = current.size.toString, suiteName = "step", annotations = annotations)
           case f @ Fragment(NoText, e, _)               => createDescription(className, label = current.size.toString, suiteName = "action", annotations = annotations)
-          case f @ Fragment(d, e, _)                    => createDescription(className, label = current.size.toString, id = f.location.hashCode.toString, testName = testName(d.show, parentPath(current.parents.map(_._2))), annotations = annotations)
+          case f @ Fragment(d, e, _)                    => createDescription(className, label = current.size.toString, id = f.hashCode.toString, testName = testName(d.show, parentPath(current.parents.map(_._2))), annotations = annotations)
         }
         (current.getLabel, description)
     }


### PR DESCRIPTION
This fixes an issue where JUnit `Description`s, generated in the same location (e.g. a loop, `Fragments.foreach`), don't have a unique id.