### PR TITLE
Fix for failing JUnitXmlPrinterSpec 

### DIFF
--- a/junit/jvm/src/test/scala/org/specs2/reporter/JUnitXmlPrinterSpec.scala
+++ b/junit/jvm/src/test/scala/org/specs2/reporter/JUnitXmlPrinterSpec.scala
@@ -108,7 +108,7 @@ is formatted for JUnit reporting tools.
     val mockFs = new FileSystem {
       var out: String = ""
       override def writeFile(filePath: FilePath, content: String): Operation[Unit] =
-        Operations.ok(())
+        Operations.ok(out = content)
     }
     val env = env1.copy(fileSystem = mockFs)
     Reporter.report(env, List(JUnitXmlPrinter))(SpecStructure(SpecHeader(getClass)).setFragments(fs)).runOption(env1.specs2ExecutionEnv)


### PR DESCRIPTION
This PR reverts a (possibly unintentional) removal of `content` assignment  to the mock filesystem, that was part of 389ed91317d6cbb98a081cb9fd165cd26f42e982 (upgrad to scala 2.13.0-M3).