### PR TITLE
Fix for failing DiffableSpec in 2.12.x

### DIFF
--- a/tests/src/test/scala/org/specs2/matcher/describe/DiffableSpec.scala
+++ b/tests/src/test/scala/org/specs2/matcher/describe/DiffableSpec.scala
@@ -155,6 +155,9 @@ Compare result
   def ccFieldDiffable = {
     case class A(value: Int)
     case class B(name: String, value: List[A])
+    implicit val diffableA: Diffable[A] = new Diffable[A] {
+      def diff(actual: A, expected: A): ComparisonResult = CaseClassIdentical("A")
+    }
     val name = "name"
     val b1 = B(name, List(A(5)))
     val b2 = B(name, List(A(6)))


### PR DESCRIPTION
This PR restores the (possibly erroneously) removed implicit instance of `Diffable`, so that the 2.12.x build passes the DiffableSpec tests.