### PR TITLE
Fixing a compilation error with Scala 2.13.x

### DIFF
--- a/junit/jvm/src/test/scala/org/specs2/reporter/JUnitXmlPrinterSpec.scala
+++ b/junit/jvm/src/test/scala/org/specs2/reporter/JUnitXmlPrinterSpec.scala
@@ -108,7 +108,7 @@ is formatted for JUnit reporting tools.
     val mockFs = new FileSystem {
       var out: String = ""
       override def writeFile(filePath: FilePath, content: String): Operation[Unit] =
-        Operations.ok(out = content)
+        Operations.ok(this.out = content)
     }
     val env = env1.copy(fileSystem = mockFs)
     Reporter.report(env, List(JUnitXmlPrinter))(SpecStructure(SpecHeader(getClass)).setFragments(fs)).runOption(env1.specs2ExecutionEnv)


### PR DESCRIPTION
This fixes an error that occurs in Scala 2.13.0-M3, it fails to find the `out` field in scope, resulting in the following error:
```
[error] .../JUnitXmlPrinterSpec.scala:111: unknown parameter name: out
[error]         Operations.ok(out = content)
```

This PR fixes it by explicitly specifying `this.` keyword. 

This is also a possible bug/regression in Scala 2.13.