### PR TITLE
fix build (discovered in Scala community build)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -441,11 +441,11 @@ lazy val publicationSettings = Seq(
 lazy val notificationSettings = Seq(
   ghreleaseRepoOrg := "etorreborre",
   ghreleaseRepoName := "specs2",
-  ghreleaseNotes := {
+  ghreleaseNotes := { tagName: TagName =>
     // find the corresponding release notes
-    val notesFilePath = s"notes/${tagName.value.toUpperCase.replace("SPECS2-", "")}.markdown"
+    val notesFilePath = s"notes/${tagName.toUpperCase.replace("SPECS2-", "")}.markdown"
     try scala.io.Source.fromFile(notesFilePath).mkString
-    catch { case t: Throwable => throw new Exception(s"the path $notesFilePath not found for tag ${tagName.value}") }
+    catch { case t: Throwable => throw new Exception(s"the path $notesFilePath not found for tag $tagName") }
   },
   // just upload the notes
   ghreleaseAssets := Seq()


### PR DESCRIPTION
this reverts a piece of ebc48e9276 that I don't even understand
why it compiled. the type of `ghreleaseNotes` is `String => String`

in the context of the community build, what happens is that dbuild
manipulates the `version` setting to something long and gruesome like
4.2.0-DBUILDXD306556371FB43C35AA0C7F2F61228127D1882C3