### PR TITLE
dependency version bumps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -343,7 +343,7 @@ lazy val compilationSettings = Seq(
         "-Ywarn-value-discard",
         "-deprecation:false", "-Xcheckinit", "-unchecked", "-feature", "-language:_"),
   scalacOptions += "-Ypartial-unification",
-  addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.6"),
+  addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7"),
   scalacOptions in Test               ++= Seq("-Yrangepos"),
   scalacOptions in (Compile, doc)     ++= Seq("-feature", "-language:_"),
   scalacOptions in (Compile, console) := Seq("-Yrangepos", "-feature", "-language:_"),

--- a/project/depends.scala
+++ b/project/depends.scala
@@ -28,11 +28,11 @@ object depends {
         scalaJSStage in Test := FastOptStage)
 
   def scalaParser = Def.setting {
-    Seq("org.scala-lang.modules" %%% "scala-parser-combinators" % "1.1.0") 
+    Seq("org.scala-lang.modules" %%% "scala-parser-combinators" % "1.1.1")
   }
 
   def scalaXML = Def.setting {
-    Seq("org.scala-lang.modules" %% "scala-xml" % "1.0.6")
+    Seq("org.scala-lang.modules" %% "scala-xml" % "1.1.0")
   }
 
   def kindp(scalaVersion: String) =


### PR DESCRIPTION
these are the versions that are published for 2.13.0-M4, so this is
needed to prepare for M4 support (once ScalaCheck has published)