### PR TITLE
prepare Scala 2.13. immutable.HashMap is abstract class since Scala 2.13.0-M4

### DIFF
--- a/fp/shared/src/main/scala/org/specs2/fp/Memo.scala
+++ b/fp/shared/src/main/scala/org/specs2/fp/Memo.scala
@@ -36,7 +36,7 @@ object Memo {
 
   import collection.immutable.{HashMap, ListMap, TreeMap}
 
-  def immutableHashMapMemo[K, V]: Memo[K, V] = immutableMapMemo(new HashMap[K, V])
+  def immutableHashMapMemo[K, V]: Memo[K, V] = immutableMapMemo(HashMap.empty[K, V])
 
   def immutableListMapMemo[K, V]: Memo[K, V] = immutableMapMemo(new ListMap[K, V])
 


### PR DESCRIPTION
https://github.com/scala/scala/blob/v2.13.0-M4/src/library/scala/collection/immutable/HashMap.scala#L30