### PR TITLE
use JavaConverters instead of JavaConversions

### DIFF
--- a/common/shared/src/main/scala/org/specs2/main/SystemProperties.scala
+++ b/common/shared/src/main/scala/org/specs2/main/SystemProperties.scala
@@ -1,7 +1,7 @@
 package org.specs2
 package main
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import text.NotNullStrings._
 import text.FromString
 
@@ -13,7 +13,7 @@ trait SystemProperties {
 
   /** copy system properties on first access to avoid possible concurrent modification exceptions later */
   private lazy val systemProperties =
-    synchronized(System.getProperties.stringPropertyNames.toList.foldLeft(Map[String, String]()) { (res, key) =>
+    synchronized(System.getProperties.stringPropertyNames.asScala.toList.foldLeft(Map[String, String]()) { (res, key) =>
       res.updated(key,System.getProperty(key))
     })
 

--- a/guide/src/test/scala/org/specs2/guide/Isolation.scala
+++ b/guide/src/test/scala/org/specs2/guide/Isolation.scala
@@ -4,8 +4,6 @@ package guide
 import java.io.{PrintWriter, ByteArrayOutputStream}
 import java.util.Properties
 
-import scala.collection.JavaConversions._
-
 object Isolation extends UserGuidePage { def is = s2"""
 
 Unit specifications allow to nest blocks, as if they were different contexts, going from the more general to the more specific. It can be very tempting, for some applications, to include some mutable state representing data in more and more specific contexts. However, this can be problematic because:


### PR DESCRIPTION
https://github.com/scala/scala/blob/v2.12.6/src/library/scala/collection/JavaConversions.scala

deprecated since Scala 2.12. removed Scala 2.13