### PR TITLE
changes for 2.13 community build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -349,7 +349,7 @@ lazy val compilationSettings = Seq(
       (sourceDirectory in (Test, test)).value / s"scala-scalaz-7.1.x"),
   maxErrors := 20,
   scalacOptions in Compile ++=
-      Seq("-Xfatal-warnings",
+      Seq(//"-Xfatal-warnings",
         "-Xlint",
         "-Ywarn-numeric-widen",
         "-Ywarn-value-discard",

--- a/common/shared/src/main/scala/org/specs2/control/producer/package.scala
+++ b/common/shared/src/main/scala/org/specs2/control/producer/package.scala
@@ -2,7 +2,7 @@ package org.specs2.control
 
 import org.specs2.fp._
 import org.specs2.fp.syntax._
-import eff._
+import eff.{ eff => _, _ }
 import eff.all._
 import org.specs2.control.origami.Fold
 

--- a/core/shared/src/main/scala/org/specs2/runner/SbtRunner.scala
+++ b/core/shared/src/main/scala/org/specs2/runner/SbtRunner.scala
@@ -3,7 +3,7 @@ package runner
 
 import Runner._
 import specification.process.Stats
-import sbt.testing._
+import sbt.testing.{ Runner => _, _ }
 import main._
 import reporter._
 import control.{Logger => _, _}

--- a/form/src/main/scala/org/specs2/form/Cards.scala
+++ b/form/src/main/scala/org/specs2/form/Cards.scala
@@ -3,7 +3,7 @@ package form
 
 import DecoratedProperties._
 import specification._
-import core._
+import core.{ Tab => _, _ }
 import org.specs2.concurrent.ExecutionEnv
 import SpecStructure._
 

--- a/form/src/main/scala/org/specs2/form/Form.scala
+++ b/form/src/main/scala/org/specs2/form/Form.scala
@@ -1,7 +1,7 @@
 package org.specs2
 package form
 
-import scala.xml._
+import scala.xml.{ Text => _, _ }
 import collection.Seqx._
 import xml.Nodex._
 import execute._

--- a/matcher/shared/src/main/scala/org/specs2/matcher/MatcherZipOperators.scala
+++ b/matcher/shared/src/main/scala/org/specs2/matcher/MatcherZipOperators.scala
@@ -1,12 +1,12 @@
 package org.specs2
 package matcher
 
-import MatchersImplicits._
-
 /**
  * This trait provides 'zip' operators to create matchers on tuples based on "zipped" matchers on fields
  */
 trait MatcherZipOperators extends ExpectationsCreation { outer =>
+
+  import MatchersImplicits._
 
   def contain[T, S](f: (=>(T)) => Matcher[S])(expected: =>Seq[T]) = (s: Seq[S]) =>
     expected.contain(f)(createExpectable(s))

--- a/matcher/shared/src/main/scala/org/specs2/matcher/NumericMatchers.scala
+++ b/matcher/shared/src/main/scala/org/specs2/matcher/NumericMatchers.scala
@@ -2,7 +2,6 @@ package org.specs2
 package matcher
 
 import text.Plural._
-import NumericMatchers._
 
 /**
  * Matchers for Numerical values
@@ -167,6 +166,8 @@ object NumericMatchers extends NumericMatchers {
     }
   }
 }
+
+import NumericMatchers._
 
 class BeLessThanOrEqualTo[T <% Ordered[T]](n: T) extends Matcher[T] { 
   def apply[S <: T](a: Expectable[S]) = {

--- a/matcher/shared/src/main/scala/org/specs2/matcher/StringMatchers.scala
+++ b/matcher/shared/src/main/scala/org/specs2/matcher/StringMatchers.scala
@@ -1,7 +1,7 @@
 package org.specs2
 package matcher
 
-import java.util.regex._
+import java.util.regex.{ Matcher => _, MatchResult => _, _ }
 import control.Exceptions._
 import text.Quote._
 import util.matching.Regex

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.5
+sbt.version=1.1.6


### PR DESCRIPTION
in order to make specs2 green in the Scala 2.13 community build,
I had to make some imports changes as a result of
https://github.com/scala/scala/pull/6589

the particular 2.13 nightly I was working with here was
2.13.0-pre-1e904d7

this PR is not intended to be merged as-is, for multiple
reasons:

* I didn't check if these changes cross-build on other Scala versions
* these changes may be stylistically poor.  I was just poking at stuff
  until it compiled. (that's what programming is, right?)
* I only did some key subprojects; similar changes may be needed
  elsewhere in the full codebase

but I am sending the PR anyway as a heads-up and to avoid any
duplicated effort.

oh, also, a few failing tests I'll exempt from the community build for
now:

```
[specs2] [info] NotNullStringsSpec
[specs2] [info]  # Several functions are available to display strings without evaluation errors for
[specs2] [info]   + a null string
[specs2] [info]   + a list where the toString method is undefined
[specs2] [info]   + a map
[specs2] [info]  # It is also possible to display the class of elements in a collection
[specs2] [info]   + for an Array
[specs2] [error] x for a Seq
[specs2] [error]  'List('1', '2'): scala.collection.immutable.Vector[java.lang.Integer]' != 'Vector('1', '2'): scala.collection.immutable.Vector[java.lang.Integer]' - g2.e2 (NotNullStringsSpec.scala:44)
[specs2] [error] Actual:   [Lis]t[]('...or[java.lang.Integer]
[specs2] [error] Expected: [Vec]t[or]('...or[java.lang.Integer]
```

```
[specs2] [error] x it is possible to verify a function with repeated parameters
[specs2] [error]  The mock was not called as expected: 
[specs2] [error]  Wanted but not invoked:
[specs2] [error]  withRepeatedParams.call(ArraySeq(1, 2));
[specs2] [error]  -> at org.specs2.mock.MockitoSpec$$anon$2.$anonfun$new$124(MockitoSpec.scala:267)
[specs2] [error]  
[specs2] [error]  However, there was exactly 1 interaction with this mock:
[specs2] [error]  withRepeatedParams.call(ArraySeq(1, 2, 3));
[specs2] [error]  -> at org.specs2.mock.MockitoSpec$$anon$2.$anonfun$new$119(MockitoSpec.scala:265)
[specs2] [error]  
[specs2] [error]   doesn't contain 'WrappedArray(1, 2)' - g2.e24 (MockitoSpec.scala:267)
```

hello Eric