### PR TITLE
Take constant stack while running examples in parallel (fix #682)

### DIFF
--- a/common/shared/src/main/scala/org/specs2/control/eff/FutureEffect.scala
+++ b/common/shared/src/main/scala/org/specs2/control/eff/FutureEffect.scala
@@ -42,8 +42,8 @@ object TimedFuture {
 
     def ap[A, B](fa: =>TimedFuture[A])(ff: =>TimedFuture[(A) => B]): TimedFuture[B] = {
       val newCallback = { es: ExecutorServices =>
-        val ffRan = ff.runNow(es)
-        val faRan = fa.runNow(es)
+        val ffRan = Future(ff.runNow(es))(es.executionContext).flatten
+        val faRan = Future(fa.runNow(es))(es.executionContext).flatten
         faRan.flatMap(a => ffRan.map(f => f(a))(es.executionContext))(es.executionContext)
       }
       TimedFuture(newCallback)


### PR DESCRIPTION
This should fix #682 by suspending the `runNow` calls to the execution context, so that constant stack is taken. ~~I am going to check today that this fixes the issue, but I can't see how it wouldn't.~~

I can't check that this fixes my issue directly, because it's nondeterministic.