### PR TITLE
better levels for non mutable specifications

### DIFF
--- a/core/jvm/src/test/scala/org/specs2/specification/LevelsSpec.scala
+++ b/core/jvm/src/test/scala/org/specs2/specification/LevelsSpec.scala
@@ -34,7 +34,7 @@ class LevelsSpec(ee: ExecutionEnv) extends Spec { def is = s2"""
       "|",
       "`- Fragment(e2)")
 
-    def e1: MatchResult[Option[Tree[Fragment]]] = treeMap(new mutableSpec { "t1" >> { "e1" in ok; "e2" in ok } }.is.fragments)(mapper)(ee) must beDrawnAs(
+    def e1: MatchResult[Option[Tree[Fragment]]] = treeMap(new mutableSpec { "t1" >> { "e1" in ok; "e2" >> ok } }.is.fragments)(mapper)(ee) must beDrawnAs(
       "Fragment(root)",
       "|",
       "`- Fragment(t1)",
@@ -56,6 +56,7 @@ class LevelsSpec(ee: ExecutionEnv) extends Spec { def is = s2"""
 
     def e3: MatchResult[Option[Tree[Fragment]]] = treeMap(new mutableSpec {
       "t1" >> {
+        br
         "t2" >> {
           ok
           Fragment.foreach(1 to 3) { i =>

--- a/core/jvm/src/test/scala/org/specs2/specification/LevelsSpec.scala
+++ b/core/jvm/src/test/scala/org/specs2/specification/LevelsSpec.scala
@@ -7,6 +7,8 @@ import Fragment._
 import process._
 import Levels._
 import org.specs2.concurrent.ExecutionEnv
+import org.specs2.matcher.MatchResult
+import org.specs2.specification.dsl.AcceptanceDsl
 
 class LevelsSpec(ee: ExecutionEnv) extends Spec { def is = s2"""
 
@@ -14,13 +16,25 @@ class LevelsSpec(ee: ExecutionEnv) extends Spec { def is = s2"""
  This is used with mutable specifications to be able to display a tree of examples (Acceptance specification just list their examples on the same level)
 
   A tree of fragments can be created from the leveled blocks
-    for "t1" >> { "ex1" in ok ;  "ex2" in ok }                                           ${tree().e1}
-    for "t1" >> { "t2" >> { "ex1" in ok ;  "ex2" in ok } }                               ${tree().e2}
+    for mutable spec:"e1" in ok; "e2" in ok                                              ${tree().e0}
+    for mutable spec:"t1" >> { "ex1" in ok ;  "ex2" in ok }                              ${tree().e1}
+    for mutable spec:"t1" >> { "t2" >> { "ex1" in ok ;  "ex2" in ok } }                  ${tree().e2}
+    for mutable spec with three nested levels and 'for loop'                             ${tree().e3}
+    for non mutable spec                                                                 ${tree().e4}
+    for non mutable spec with fragments                                                  ${tree().e5}
                                                                                          """
 
-  trait spec extends org.specs2.mutable.Specification
-  case class tree() {
-    def e1 = treeMap(new spec { "t1" >> { "e1" in ok; "e2" in ok } }.is.fragments)(mapper)(ee) must beDrawnAs(
+  trait mutableSpec extends org.specs2.mutable.Specification
+  trait spec extends org.specs2.Specification
+  case class tree() extends AcceptanceDsl {
+    def e0: MatchResult[Option[Tree[Fragment]]] = treeMap(new mutableSpec { "e1" in ok; "e2" in ok }.is.fragments)(mapper)(ee) must beDrawnAs(
+      "Fragment(root)",
+      "|",
+      "+- Fragment(e1)",
+      "|",
+      "`- Fragment(e2)")
+
+    def e1: MatchResult[Option[Tree[Fragment]]] = treeMap(new mutableSpec { "t1" >> { "e1" in ok; "e2" in ok } }.is.fragments)(mapper)(ee) must beDrawnAs(
       "Fragment(root)",
       "|",
       "`- Fragment(t1)",
@@ -29,7 +43,7 @@ class LevelsSpec(ee: ExecutionEnv) extends Spec { def is = s2"""
       "   |",
       "   `- Fragment(e2)")
 
-    def e2 = treeMap(new spec { "t1" >> { "e1" in ok }; "t2" >> { "e2" in ok } }.is.fragments)(mapper)(ee) must beDrawnAs(
+    def e2: MatchResult[Option[Tree[Fragment]]] = treeMap(new mutableSpec { "t1" >> { "e1" in ok }; "t2" >> { "e2" in ok } }.is.fragments)(mapper)(ee) must beDrawnAs(
       "Fragment(root)",
       "|",
       "+- Fragment(t1)",
@@ -40,17 +54,110 @@ class LevelsSpec(ee: ExecutionEnv) extends Spec { def is = s2"""
       "   |",
       "   `- Fragment(e2)")
 
+    def e3: MatchResult[Option[Tree[Fragment]]] = treeMap(new mutableSpec {
+      "t1" >> {
+        "t2" >> {
+          ok
+          Fragment.foreach(1 to 3) { i =>
+            "e" + i in ok
+          }
+          "t3" >> {
+            "e4" in ok
+          }
+
+          "e5" in ok
+        }
+        "e6" in ok
+      }
+    }.is.fragments)(mapper)(ee) must beDrawnAs(
+      "Fragment(root)",
+      "|",
+      "`- Fragment(t1)",
+      "   |",
+      "   +- Fragment(t2)",
+      "   |  |",
+      "   |  +- Fragment(e1)",
+      "   |  |",
+      "   |  +- Fragment(e2)",
+      "   |  |",
+      "   |  +- Fragment(e3)",
+      "   |  |",
+      "   |  +- Fragment(t3)",
+      "   |  |  |",
+      "   |  |  `- Fragment(e4)",
+      "   |  |",
+      "   |  `- Fragment(e5)",
+      "   |",
+      "   `- Fragment(e6)")
+
+    def e4: MatchResult[Option[Tree[Fragment]]] = treeMap(new spec { def is = s2"""
+        t11
+          e11 $ok
+          e22 $ok
+          """
+    }.is.fragments)(mapper)(ee) must beDrawnAs(
+      "Fragment(root)",
+      "|",
+      "+- Fragment(t11)",
+      "|",
+      "+- Fragment(e11)",
+      "|",
+      "`- Fragment(e22)"
+    )
+
+    def e5: MatchResult[Option[Tree[Fragment]]] = treeMap(new spec { def is = s2"""
+        Explanation Text.
+
+        First starting test line
+
+          example no. one $ok
+          example no. two $ok
+
+        Second starting test line
+          first set of fragments $fragments1
+          second set of fragments $fragments2
+          """
+    }.is.fragments)(mapper)(ee) must beDrawnAs(
+      "Fragment(root)",
+      "|",
+      "+- Fragment(Explanation Text. First starting test line)",
+      "|",
+      "+- Fragment(example no. one)",
+      "|",
+      "+- Fragment(example no. two)",
+      "|",
+      "+- Fragment(Second starting test line first set of fragments)",
+      "|",
+      "+- Fragment(example no. one from first set)",
+      "|",
+      "+- Fragment(example no. two from first set)",
+      "|",
+      "+- Fragment(second set of fragments)",
+      "|",
+      "+- Fragment(example no. one from second set)",
+      "|",
+      "`- Fragment(example no. two from second set)"
+    )
+
+    private def fragments1 = fragments("first")
+    private def fragments2 = fragments("second")
+
+    private def fragments(description: String) = {
+      p^
+        s"example no. one from $description set"  ! success ^br^
+        s"example no. two from $description set"  ! success ^br
+    }
+
     // use this mapper to keep only text and examples
-    val mapper = (f: Fragment) => {
+    private val mapper = (f: Fragment) => {
       f match {
-        case Fragment(Text(t), _, _) if t.trim.isEmpty => None
-        case Fragment(Text(t), e, l)  => Some(Fragment(Text(t.trim), e, l))
-        case other                       => None
+        case Fragment(Text(t), _, _) if t.trim.isEmpty  => None
+        case Fragment(Text(t), e, l)                    => Some(Fragment(Text(t.trim.replaceAll("\\s+"," ")), e, l))
+        case _                                          => None
       }
     }
-    def beDrawnAs(lines: String*) = be_==(lines.mkString("", "\n", "\n")) ^^ {
+    private def beDrawnAs(lines: String*) = be_==(lines.mkString("", "\n", "\n")) ^^ {
       tree: Option[Tree[Fragment]] => tree.map(_.drawTree).getOrElse("no tree!")
     }
   }
-
 }

--- a/core/shared/src/main/scala/org/specs2/specification/process/Levels.scala
+++ b/core/shared/src/main/scala/org/specs2/specification/process/Levels.scala
@@ -29,19 +29,15 @@ trait Levels {
     levelsProcess1.map { case (f, level) => (f, level.l) }
   
   def levelsProcess1: AsyncTransducer[Fragment, (Fragment, Level)] = {
-    def sameLevel(f: Fragment, level: Level) = ((f, level), level)
     def nextLevel(f: Fragment, level: Level, next: Level) = ((f, level), next)
 
     state[ActionStack, Fragment, (Fragment, Level), Level](Level()) {
       // level goes +1 when a new block starts
-      case (f @ Fragment(Start,_ ,_), level) => nextLevel(f, level, level.copy(start = true, incrementNext = false))
-      case (f @ Fragment(End,_ ,_), level)   => nextLevel(f, level, level.copy(start = false, incrementNext = false, max(0, level.l - 1)))
-      case (f , level) if Fragment.isText(f) && (level.start || level.incrementNext)
-                                             => nextLevel(f, level, level.copy(start = false, incrementNext = true))
-      case (f , level) if Fragment.isText(f) => nextLevel(f, level, level.copy(start = false, incrementNext = false))
-      case (f, level)                        =>
-        if (level.incrementNext) nextLevel(f, level.copy(l = level.l + 1), level.copy(start = false, incrementNext = false, l = level.l + 1))
-        else                     sameLevel(f, level)
+      case (f @ Fragment(Start,_ ,_), level) => nextLevel(f, level, level.copy(start = true))
+      case (f @ Fragment(End,_ ,_), level)   => nextLevel(f, level, level.copy(start = false, l = max(0, level.l - 1)))
+      case (f , level) if Fragment.isText(f) && level.start
+                                             => nextLevel(f, level, level.copy(start = false, l = level.l + 1))
+      case (f, level)                        => nextLevel(f, level, level.copy(start = false))
     }
   }
 

--- a/core/shared/src/main/scala/org/specs2/specification/process/Levels.scala
+++ b/core/shared/src/main/scala/org/specs2/specification/process/Levels.scala
@@ -35,10 +35,12 @@ trait Levels {
     state[ActionStack, Fragment, (Fragment, Level), Level](Level()) {
       // level goes +1 when a new block starts
       case (f @ Fragment(Start,_ ,_), level) => nextLevel(f, level, level.copy(start = true, incrementNext = false))
-      case (f , level) if Fragment.isText(f) => nextLevel(f, level, level.copy(start = true, incrementNext = true))
       case (f @ Fragment(End,_ ,_), level)   => nextLevel(f, level, level.copy(start = false, incrementNext = false, max(0, level.l - 1)))
+      case (f , level) if Fragment.isText(f) && (level.start || level.incrementNext)
+                                             => nextLevel(f, level, level.copy(start = false, incrementNext = true))
+      case (f , level) if Fragment.isText(f) => nextLevel(f, level, level.copy(start = false, incrementNext = false))
       case (f, level)                        =>
-        if (level.incrementNext) nextLevel(f, level, level.copy(start = false, incrementNext = false, l = level.l + 1))
+        if (level.incrementNext) nextLevel(f, level.copy(l = level.l + 1), level.copy(start = false, incrementNext = false, l = level.l + 1))
         else                     sameLevel(f, level)
     }
   }

--- a/html/src/test/scala/org/specs2/reporter/HtmlBodyPrinterSpec.scala
+++ b/html/src/test/scala/org/specs2/reporter/HtmlBodyPrinterSpec.scala
@@ -3,24 +3,31 @@ package reporter
 
 import io.DirectoryPath
 import main.Arguments
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.control.ExecuteActions._
 import org.specs2.matcher.XmlMatchers
 import org.specs2.specification.Forms
-import specification.process.Level
-import specification.core.Fragment
+import specification.process.{Level, Stats}
+import specification.core.{Fragment, SpecStructure}
 
 import scala.xml.NodeSeq
 import org.specs2.text.AnsiColors
+import org.specs2.time.SimpleTimer
 
-object HtmlBodyPrinterSpec extends Specification with Forms with XmlMatchers { def is = s2"""
+class HtmlBodyPrinterSpec(ee: ExecutionEnv) extends Specification with Forms with XmlMatchers { def is = s2"""
 
  A hidden reference must not be printed $hidden
  A form must be printed $printForm
 
  Ansi colors must be removed in text fragments $ansiColors
+
+ Fragments must have proper levels in html body $htmlBody
 """
 
   def hidden = {
-    print(link(HtmlBodyPrinterSpec).hide) must beEmpty
+    print(link(new spec { def is = s2"""
+        Explanation Text.
+       example no. one $ok"""}).hide) must beEmpty
   }
 
   def printForm = {
@@ -34,4 +41,101 @@ object HtmlBodyPrinterSpec extends Specification with Forms with XmlMatchers { d
 
   def print(f: Fragment): NodeSeq =
     HtmlBodyPrinter.printFragment(f, success, Arguments(), Level.Root, DirectoryPath.Root, pandoc = true)
+
+  trait spec extends org.specs2.Specification
+
+  def htmlBody = {
+    val fragments = new spec { def is = s2"""
+        Explanation Text.
+
+        First starting test line
+
+          example no. one $ok
+          example no. two $ok
+
+        Second starting test line
+          first set of fragments $fragments1
+          second set of fragments $fragments2
+          """
+    }.is.fragments
+    println(fragments.contents.runList.runOption(ee))
+
+    makeBody(fragments)(ee).map(_.trim.replaceAll("\\s+","")).runOption === Some(
+      """
+        |<text class="ok">
+        |   <br/>Explanation Text. First starting test line<br/>
+        |</text>
+        |<ul>
+        |   <li class="example skipped ok">
+        |       <text>example no. one</text>
+        |       <br/>
+        |       <message class="skipped"></message>
+        |   </li>
+        |</ul>
+        |<ul>
+        |   <li class="example skipped ok">
+        |       <text>example no. two</text>
+        |       <br/>
+        |       <message class="skipped"></message>
+        |   </li>
+        |</ul>
+        |<text class="ok">
+        |   <br/>Second starting test line first set of fragments
+        |</text>
+        |<br/>
+        |<br/>
+        |<li class="example skipped ok">
+        |   <text>example no. one from first set</text>
+        |   <br/>
+        |   <message class="skipped"></message>
+        |</li>
+        |<br/>
+        |<li class="example skipped ok">
+        |   <text>example no. two from first set</text>
+        |   <br/>
+        |   <message class="skipped"></message>
+        |</li>
+        |<br/>
+        |<text class="ok">
+        |   <br/>second set of fragments
+        |</text>
+        |<br/>
+        |<br/>
+        |<li class="example skipped ok">
+        |   <text>example no. one from second set</text>
+        |   <br/>
+        |   <message class="skipped"></message>
+        |</li>
+        |<br/>
+        |<li class="example skipped ok">
+        |   <text>example no. two from second set</text>
+        |   <br/>
+        |   <message class="skipped"></message>
+        |</li>
+        |<br/>
+      """.stripMargin.trim.replaceAll("\\s+",""))
+  }
+
+  private def fragments1 = fragments("first")
+  private def fragments2 = fragments("second")
+
+  private def fragments(description: String) = {
+    p^
+      s"example no. one from $description set"  ! success ^br^
+      s"example no. two from $description set"  ! success ^br
+  }
+
+  private def makeBody(specStructure: SpecStructure)(executionEnv: ExecutionEnv) =
+    HtmlBodyPrinter.makeBody(specStructure, Stats(), new SimpleTimer(), options, Arguments(), pandoc = false)(executionEnv)
+
+  def options = HtmlOptions(
+    outDir = HtmlOptions.outDir,
+    baseDir = HtmlOptions.baseDir,
+    template = HtmlOptions.outDir.toFilePath,
+    variables = Map(),
+    noStats = true,
+    search = false,
+    toc = false,
+    tocEntryMaxSize = 18,
+    warnMissingSeeRefs = true)
 }

--- a/junit/jvm/src/test/scala/org/specs2/reporter/JUnitXmlPrinterSpec.scala
+++ b/junit/jvm/src/test/scala/org/specs2/reporter/JUnitXmlPrinterSpec.scala
@@ -51,6 +51,8 @@ is formatted for JUnit reporting tools.
     names must be escaped                                                                                               ${message.e8}
   """
 
+  private val factory = fragmentFactory; import factory._
+
   val printer = JUnitXmlPrinter
 
   object outputDir {
@@ -89,7 +91,7 @@ is formatted for JUnit reporting tools.
 
   object test {
     def e1 = { print(ownEnv)("t1" ^ br ^ "e1<>&\"" ! success) must \\("testcase", "classname" -> "org.specs2.reporter.JUnitXmlPrinterSpec") }
-    def e2 = { print(ownEnv)("t1" ^ br ^ "e1<>&\"" ! success) must \\("testcase", "name" -> scala.xml.Utility.escape("t1::e1<>&\"")) }
+    def e2 = { print(ownEnv)(start ^ "t1" ^ br ^ "e1<>&\"" ! success ^ end) must \\("testcase", "name" -> scala.xml.Utility.escape("t1::e1<>&\"")) }
     def e3 = { print(ownEnv)("t1" ^ br ^ "e1<>&\"" ! success) must \\("testcase", "time") }
   }
 
@@ -101,7 +103,7 @@ is formatted for JUnit reporting tools.
     def e5 = { print(ownEnv)("t1" ^ br ^ "e3" ! failure) must \\("failure", "type" -> failure.exception.getClass.getName) }
     def e6 = { print(ownEnv)("t1" ^ br ^ "e3" ! failure).toString must contain("JUnitXmlPrinterSpec.scala") }
     def e7 = { print(ownEnv)("t1" ^ br ^ "e2" ! skipped) must \\("skipped") }
-    def e8 = { print(ownEnv)("t1" ^ br ^ "<node.1/>" ! ok).toString must contain("t1::&lt;node.1/&gt;") }
+    def e8 = { print(ownEnv)(start ^ "t1" ^ br ^ "<node.1/>" ! ok ^ end).toString must contain("t1::&lt;node.1/&gt;") }
   }
 
   def printString(env1: Env)(fs: Fragments): String = {


### PR DESCRIPTION
Non mutable specifications run by JUnitRunner were not properly printed. Here is example: https://github.com/kaatzee/specs2Issues/blob/master/src/test/scala/s2i/nonmutablespecification/NonMutableIssueSpec.scala (just run it via JUnitRunner).

I have corected calculating 'levels' of 'fragments' and now it looks much better. Not sure if it is desired output, but it is similar to outputs from other notifiers or printers.

Also in Levels trait there is 'fold' method which had had the same (almost) behaviour, but I haven't changed it. It is used by HtmlPrinter, but I haven't checked if it suffers for the same issue (probably yes?).  