### PR TITLE
Report failure to junit on spec init errors

### DIFF
--- a/core/js/src/main/scala/org/specs2/control/ExecuteActions.scala
+++ b/core/js/src/main/scala/org/specs2/control/ExecuteActions.scala
@@ -68,6 +68,9 @@ trait ExecuteActions {
         case Right(a) => Option(a)
         case Left(t) => println("error while interpreting an action "+t.fold(Throwables.render, f => f)); None
       }
+
+    def runEither(ee: ExecutionEnv): Either[Error, T] =
+      runAction(action, println)(ee)
   }
 
 

--- a/core/jvm/src/main/scala/org/specs2/control/ExecuteActions.scala
+++ b/core/jvm/src/main/scala/org/specs2/control/ExecuteActions.scala
@@ -82,6 +82,9 @@ trait ExecuteActions {
         case Right(a) => Option(a)
         case Left(t) => println("error while interpreting an action "+t.fold(Throwables.render, f => f)); None
       }
+
+    def runEither(ee: ExecutionEnv): Either[Error, T] =
+      runAction(action, println)(ee)
   }
 
 

--- a/junit/shared/src/main/scala/org/specs2/runner/JUnitRunner.scala
+++ b/junit/shared/src/main/scala/org/specs2/runner/JUnitRunner.scala
@@ -1,8 +1,8 @@
 package org.specs2
 package runner
 
-import org.junit.runner.manipulation.{NoTestsRemainException, Filterable}
-import org.junit.runner.notification.RunNotifier
+import org.junit.runner.manipulation.{Filterable, NoTestsRemainException}
+import org.junit.runner.notification.{Failure, RunNotifier}
 import main._
 import specification.process.Stats
 import control.Actions._
@@ -44,9 +44,14 @@ class JUnitRunner(klass: Class[_]) extends org.junit.runner.Runner with Filterab
 
   /** run the specification with a Notifier */
   def run(n: RunNotifier): Unit = {
-    try runWithEnv(n, env).runOption(env.specs2ExecutionEnv)
+    try {
+      runWithEnv(n, env).runEither(env.specs2ExecutionEnv) match {
+        case Right(_) => ()
+        case Left(Left(throwable)) => n.fireTestFailure(new Failure(getDescription, throwable))
+        case Left(Right(error)) => n.fireTestFailure(new Failure(getDescription, new RuntimeException(error)))
+      }
+    }
     finally env.shutdown
-    ()
   }
 
   /** run the specification with a Notifier and an environment */

--- a/junit/shared/src/main/scala/org/specs2/runner/JUnitRunner.scala
+++ b/junit/shared/src/main/scala/org/specs2/runner/JUnitRunner.scala
@@ -47,8 +47,7 @@ class JUnitRunner(klass: Class[_]) extends org.junit.runner.Runner with Filterab
     try {
       runWithEnv(n, env).runEither(env.specs2ExecutionEnv) match {
         case Right(_) => ()
-        case Left(Left(throwable)) => n.fireTestFailure(new Failure(getDescription, throwable))
-        case Left(Right(error)) => n.fireTestFailure(new Failure(getDescription, new RuntimeException(error)))
+        case Left(error) => n.fireTestFailure(new Failure(getDescription, error.fold(identity _, new RuntimeException(_))))
       }
     }
     finally env.shutdown


### PR DESCRIPTION
We are using specs2 through gradle and when a failure happens during spec initialisation it only produces a log line to stdout, but gradle will happily report that 0 / 0 test succeeded. Currently in our project we overrode the run method like you can see in this PR (by extending the JUnit runner). I'm unsure whether this is okay / idiomatic to do, and also unsure how to test this properly, so this PR is mainly a request / question about this topic.