### PR TITLE
fix compile error with latest Scala 2.13.x

### DIFF
--- a/form/src/test/scala/org/specs2/form/PropSpec.scala
+++ b/form/src/test/scala/org/specs2/form/PropSpec.scala
@@ -3,7 +3,7 @@ package form
 
 import control.Property
 import execute._
-import sys._
+import sys.error
 import specification._
 import matcher._
 import MatchersImplicits._


### PR DESCRIPTION
maybe due to https://github.com/scala/scala/pull/6589

https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/1302/consoleFull

```
[specs2-more] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.13/project-builds/specs2-more-db45127d55bd79c54d280645a81534fbc13e7a8b/form/src/test/scala/org/specs2/form/PropSpec.scala:62:31: too many arguments (2) for method apply: (key: String)(implicit evidence$1: sys.Prop.Creator[T])scala.sys.Prop[T] in object Prop
[specs2-more] [error]   val nameProp = Prop("name", "eric")
[specs2-more] [error]                               ^
[specs2-more] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.13/project-builds/specs2-more-db45127d55bd79c54d280645a81534fbc13e7a8b/form/src/test/scala/org/specs2/form/PropSpec.scala:63:18: trait Prop is abstract; cannot be instantiated
[specs2-more] [error]   val noValues = new Prop("name")
[specs2-more] [error]                  ^
[specs2-more] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.13/project-builds/specs2-more-db45127d55bd79c54d280645a81534fbc13e7a8b/form/src/test/scala/org/specs2/form/PropSpec.scala:64:25: type mismatch;
[specs2-more] [error]  found   : Int(18)
[specs2-more] [error]  required: String
[specs2-more] [error]   val actualOnly = Prop(18)
[specs2-more] [error]                         ^
[specs2-more] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.13/project-builds/specs2-more-db45127d55bd79c54d280645a81534fbc13e7a8b/form/src/test/scala/org/specs2/form/PropSpec.scala:65:22: trait Prop is abstract; cannot be instantiated
[specs2-more] [error]   val expectedOnly = new Prop("", Property(), Property(18))
[specs2-more] [error]                      ^
[specs2-more] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.13/project-builds/specs2-more-db45127d55bd79c54d280645a81534fbc13e7a8b/form/src/test/scala/org/specs2/form/PropSpec.scala:66:20: wrong number of type arguments for scala.sys.Prop, should be 1
[specs2-more] [error]   val constrained: Prop[String, String] = Prop("name", "eric", (s1: String, s2: String) => s1 must contain(s2))
[specs2-more] [error]                    ^
[specs2-more] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.13/project-builds/specs2-more-db45127d55bd79c54d280645a81534fbc13e7a8b/form/src/test/scala/org/specs2/form/PropSpec.scala:66:56: too many arguments (3) for method apply: (key: String)(implicit evidence$1: sys.Prop.Creator[T])scala.sys.Prop[T] in object Prop
[specs2-more] [error]   val constrained: Prop[String, String] = Prop("name", "eric", (s1: String, s2: String) => s1 must contain(s2))
[specs2-more] [error]                                                        ^
[specs2-more] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.13/project-builds/specs2-more-db45127d55bd79c54d280645a81534fbc13e7a8b/form/src/test/scala/org/specs2/form/PropSpec.scala:67:34: too many arguments (3) for method apply: (key: String)(implicit evidence$1: sys.Prop.Creator[T])scala.sys.Prop[T] in object Prop
[specs2-more] [error]   val withMatcher = Prop("name", "eric", contain(_:String))
[specs2-more] [error]                                  ^
[specs2-more] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.13/project-builds/specs2-more-db45127d55bd79c54d280645a81534fbc13e7a8b/form/src/test/scala/org/specs2/form/PropSpec.scala:75:20: too many arguments (3) for method apply: (key: String)(implicit evidence$1: sys.Prop.Creator[T])scala.sys.Prop[T] in object Prop
[specs2-more] [error]     e6 := Prop("", 1, be_>(0).mute).execute    === Success("")
[specs2-more] [error]                    ^
[specs2-more] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.13/project-builds/specs2-more-db45127d55bd79c54d280645a81534fbc13e7a8b/form/src/test/scala/org/specs2/form/PropSpec.scala:76:20: 3 more arguments than can be applied to method apply: (key: String)(implicit evidence$1: sys.Prop.Creator[T])scala.sys.Prop[T] in object Prop
[specs2-more] [error]     e7 := Prop("", 1, 2, be_>(0).mute).execute === Success("")
[specs2-more] [error]                    ^
[specs2-more] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.13/project-builds/specs2-more-db45127d55bd79c54d280645a81534fbc13e7a8b/form/src/test/scala/org/specs2/form/PropSpec.scala:80:11: trait Prop is abstract; cannot be instantiated
[specs2-more] [error]     e1 := new Prop("name", expected = Property("fanny")).toString       === "name: _ (expected: fanny)"
[specs2-more] [error]           ^
[specs2-more] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.13/project-builds/specs2-more-db45127d55bd79c54d280645a81534fbc13e7a8b/form/src/test/scala/org/specs2/form/PropSpec.scala:80:28: not found: value expected
[specs2-more] [error]     e1 := new Prop("name", expected = Property("fanny")).toString       === "name: _ (expected: fanny)"
[specs2-more] [error]                            ^
[specs2-more] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.13/project-builds/specs2-more-db45127d55bd79c54d280645a81534fbc13e7a8b/form/src/test/scala/org/specs2/form/PropSpec.scala:81:11: trait Prop is abstract; cannot be instantiated
[specs2-more] [error]     e2 := new Prop("name", actual = Property("eric")).toString          === "name: eric"
[specs2-more] [error]           ^
[specs2-more] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.13/project-builds/specs2-more-db45127d55bd79c54d280645a81534fbc13e7a8b/form/src/test/scala/org/specs2/form/PropSpec.scala:81:28: not found: value actual
[specs2-more] [error]     e2 := new Prop("name", actual = Property("eric")).toString          === "name: eric"
[specs2-more] [error]                            ^
[specs2-more] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.13/project-builds/specs2-more-db45127d55bd79c54d280645a81534fbc13e7a8b/form/src/test/scala/org/specs2/form/PropSpec.scala:82:11: trait Prop is abstract; cannot be instantiated
[specs2-more] [error]     e3 := new Prop("name", Property("eric"), Property("eric")).toString === "name: eric"
[specs2-more] [error]           ^
[specs2-more] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.13/project-builds/specs2-more-db45127d55bd79c54d280645a81534fbc13e7a8b/form/src/test/scala/org/specs2/form/PropSpec.scala:86:24: too many arguments (2) for method apply: (key: String)(implicit evidence$1: sys.Prop.Creator[T])scala.sys.Prop[T] in object Prop
[specs2-more] [error]     e1 := Prop("name", "eric")("paolo").expected.toOption must_== Some("paolo")
[specs2-more] [error]                        ^
[specs2-more] [error] 15 errors found
[specs2-more] [error] (form / Test / compileIncremental) Compilation failed
```