### PR TITLE
in HtmlPrinter delete line between examples

### DIFF
--- a/core/shared/src/main/scala/org/specs2/specification/core/Fragment.scala
+++ b/core/shared/src/main/scala/org/specs2/specification/core/Fragment.scala
@@ -4,7 +4,9 @@ package core
 
 import execute.Result
 import fp._
-import org.specs2.control._, Actions._
+import org.specs2.control._
+import Actions._
+
 import scala.concurrent.duration.FiniteDuration
 
 /**
@@ -129,6 +131,11 @@ object Fragment {
 
   def isBacktab(f: Fragment) = f.description match {
     case Backtab(_) => true
+    case _          => false
+  }
+
+  def isBr(f: Fragment) = f.description match {
+    case Br         => true
     case _          => false
   }
 

--- a/html/src/test/scala/org/specs2/reporter/HtmlBodyPrinterSpec.scala
+++ b/html/src/test/scala/org/specs2/reporter/HtmlBodyPrinterSpec.scala
@@ -76,13 +76,11 @@ class HtmlBodyPrinterSpec(ee: ExecutionEnv) extends Specification with Forms wit
         |   <br/>
         |   <message class="skipped"></message>
         |</li>
-        |<br/>
         |<li class="example skipped ok">
         |   <text>e2</text>
         |   <br/>
         |   <message class="skipped"></message>
         |</li>
-        |<br/>
         |<li class="example skipped ok">
         |   <text>e3</text>
         |   <br/>
@@ -155,7 +153,6 @@ class HtmlBodyPrinterSpec(ee: ExecutionEnv) extends Specification with Forms wit
         |   <br/>
         |   <message class="skipped"></message>
         |</li>
-        |<br/>
         |<li class="example skipped ok">
         |   <text>example no. two from first set</text>
         |   <br/>
@@ -172,7 +169,6 @@ class HtmlBodyPrinterSpec(ee: ExecutionEnv) extends Specification with Forms wit
         |   <br/>
         |   <message class="skipped"></message>
         |</li>
-        |<br/>
         |<li class="example skipped ok">
         |   <text>example no. two from second set</text>
         |   <br/>


### PR DESCRIPTION
In html output there is a line between examples:
![](https://user-images.githubusercontent.com/10988/44276663-73dcdf00-a248-11e8-94ba-54278542f977.png)

This PR deletes this line.
