### PR TITLE
Refactor IOMatchers to add Generic

### DIFF
--- a/cats/shared/src/main/scala/org/specs2/matcher/IOMatchers.scala
+++ b/cats/shared/src/main/scala/org/specs2/matcher/IOMatchers.scala
@@ -7,61 +7,82 @@ import org.specs2.matcher.describe.Diffable
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration.FiniteDuration
 import org.specs2.text.NotNullStrings._
-import scala.concurrent.ExecutionContext.Implicits.global
 
-trait IOMatchers {
-  def returnOk[T]: IOMatcher[T] =
+trait RunTimedMatchers[F[_]] {
+
+  protected def runWithTimeout[A](fa: F[A], timeout: FiniteDuration): A
+  protected def runAwait[A](fa: F[A]) : A
+
+  def returnOk[T]: TimedMatcher[T] =
     attemptRun(ValueCheck.alwaysOk, None)
 
-  def returnValue[T](check: ValueCheck[T]): IOMatcher[T] =
+  def returnValue[T](check: ValueCheck[T]): TimedMatcher[T] =
     attemptRun(check, None)
 
-  def returnBefore[T](duration: FiniteDuration): IOMatcher[T] =
+  def returnBefore[T](duration: FiniteDuration): TimedMatcher[T] =
     attemptRun(ValueCheck.alwaysOk, Some(duration))
 
-  private[specs2] def attemptRun[T](check: ValueCheck[T], duration: Option[FiniteDuration]): IOMatcher[T] =
-    IOMatcher(check, duration)
+  protected[specs2] def attemptRun[T](check: ValueCheck[T], duration: Option[FiniteDuration]): TimedMatcher[T] =
+    new TimedMatcher(check, duration)
 
-  case class IOMatcher[T](check: ValueCheck[T], duration: Option[FiniteDuration]) extends Matcher[IO[T]] {
-    def apply[S <: IO[T]](e: Expectable[S]) = duration.fold(checkIO(e))(checkIOWithDuration(e,_))
+  class TimedMatcher[T](check: ValueCheck[T], duration: Option[FiniteDuration]) extends Matcher[F[T]] {
 
-    def checkIOWithDuration[S <: IO[T]](e: Expectable[S], d: FiniteDuration): MatchResult[S] = {
+    def apply[S <: F[T]](e: Expectable[S]) = duration.fold(checkAwait(e))(checkWithDuration(e,_))
+
+    def checkWithDuration[S <: F[T]](e: Expectable[S], d: FiniteDuration): MatchResult[S] =
       try {
-        checkResult(e)(e.value.timeout(d).unsafeRunSync())
+        checkResult(e)(runWithTimeout(e.value, d))
       } catch {
         case x: TimeoutException => timeoutResult(e,d)
         case x: Exception => errorResult(e)(x)
       }
-    }
 
-    def checkIO[S <: IO[T]](e: Expectable[S]) = {
+    def checkAwait[S <: F[T]](e: Expectable[S]) =
       try {
-        checkResult(e)(e.value.unsafeRunSync())
+        checkResult(e)(runAwait(e.value))
       } catch {
         case x: Exception => errorResult(e)(x)
       }
-    }
 
-    def before(d: FiniteDuration): IOMatcher[T] =
-      copy(duration = Some(d))
+    def before(d: FiniteDuration): TimedMatcher[T] =
+      new TimedMatcher(check, Some(d))
 
-    def withValue(check: ValueCheck[T]): IOMatcher[T] =
-      copy(check = check)
+    def withValue(check: ValueCheck[T]): TimedMatcher[T] =
+      new TimedMatcher(check, duration)
 
-    def withValue(t: T)(implicit di: Diffable[T]): IOMatcher[T] =
+    def withValue(t: T)(implicit di: Diffable[T]): TimedMatcher[T] =
       withValue(valueIsTypedValueCheck(t))
 
-    private def timeoutResult[S <: IO[T]](e: Expectable[S], d: FiniteDuration): MatchResult[S] = {
+    private def timeoutResult[S <: F[T]](e: Expectable[S], d: FiniteDuration): MatchResult[S] = {
       val message = s"Timeout after ${d.toMillis} milliseconds"
       result(false, message, message, e)
     }
 
-    private def errorResult[S <: IO[T]](e: Expectable[S])(t: Throwable): MatchResult[S] = {
+    private def errorResult[S <: F[T]](e: Expectable[S])(t: Throwable): MatchResult[S] = {
       val message = "an exception was thrown "+t.getMessage.notNull+" "+t.getClass.getName
       result(false, message, message, e)
     }
 
-    private def checkResult[S <: IO[T]](e: Expectable[S])(t: T): MatchResult[S] =
+    private def checkResult[S <: F[T]](e: Expectable[S])(t: T): MatchResult[S] =
       result(check.check(t), e)
   }
+}
+
+trait IOMatchers extends RunTimedMatchers[IO] {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  protected def runWithTimeout[A](fa: IO[A], d: FiniteDuration): A = fa.timeout(d).unsafeRunSync
+  protected def runAwait[A](fa: IO[A]) : A = fa.unsafeRunSync
+
+  protected[specs2] override def attemptRun[T](check: ValueCheck[T], duration: Option[FiniteDuration]): IOMatcher[T] =
+    IOMatcher(check, duration)
+
+  case class IOMatcher[T](check: ValueCheck[T], duration: Option[FiniteDuration])
+      extends TimedMatcher[T](check, duration) {
+    def checkIOWithDuration[S <: IO[T]](e: Expectable[S], d: FiniteDuration): MatchResult[S] =
+      checkWithDuration(e, d)
+    def checkIO[S <: IO[T]](e: Expectable[S]) = checkAwait(e)
+  }
+
 }


### PR DESCRIPTION
### Description of changes

We split the IOMatchers trait to make it independent from IO.

- We extract a generic `RuntimedMatchers` trait, which is generic on  the effect type `F[_]`, and has most methods from `IOMatchers`.
- The generic `RuntimedMatchers` defines two methods, that act as placeholders for `IO.timeout` and `IO.unsafeRunSync`.
- To the `RunTimedMatchers` trait, we add an inner `TimedMatcher` class, that has most of the logic from the `IOMatcher` class. This class has methods, akin to `checkIOWithDuration` and `checkIO`, but with different names.

Having moved most of the logic to `RuntimedMatchers`, the `IOMatcher` becomes just a specific instance of `RunTimedMatchers[IO]`, and the two methods just call the IO methods.

- We keep an `IOMatcher` inner class inside `IOMatchers`, for   compatibility. This class keeps the two `checkIOWithDuration` and `checkIO` methods above.

### Related tickets

- This changes were first proposed in a [Pull Request to `http4s`](https://github.com/http4s/http4s/pull/2080), which contains a copy of `IOMatchers`. 
- A proposal to generalise some methods of `cats.effect.IO` was made and discussed in [this issue](https://github.com/typelevel/cats-effect/issues/230). Nevertheless, since no appropriate type-class at present, declaring abstract methods in `RuntimedMatchers` is the next best. 