### PR TITLE
allow building on both JDK 8 & JDK 11

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -2,5 +2,3 @@
 -J-Xms1536m
 -J-Xmx4G
 -J-XX:ReservedCodeCacheSize=192m
--J-XX:+IgnoreUnrecognizedVMOptions
--J--add-modules=java.activation

--- a/.travis-test-only.sh
+++ b/.travis-test-only.sh
@@ -1,2 +1,2 @@
-sbt -jvm-opts .travis.jvmopts -sbt-version 1.1.5 -scala-version $TRAVIS_SCALA_VERSION ";set parallelExecution in ThisBuild := false; $1/testOnly $2 -- xonly timefactor 3 neverstore exclude travis"
+sbt -jvm-opts .travis.jvmopts -sbt-version 1.2.3 -scala-version $TRAVIS_SCALA_VERSION ";set parallelExecution in ThisBuild := false; $1/testOnly $2 -- xonly timefactor 3 neverstore exclude travis"
 

--- a/.travis-test.sh
+++ b/.travis-test.sh
@@ -1,2 +1,2 @@
-sbt -jvm-opts .travis.jvmopts -sbt-version 1.1.5 -scala-version $TRAVIS_SCALA_VERSION ";set parallelExecution in ThisBuild := false; $1/testOnly -- xonly timefactor 3 neverstore exclude travis"
+sbt -jvm-opts .travis.jvmopts -sbt-version 1.2.3 -scala-version $TRAVIS_SCALA_VERSION ";set parallelExecution in ThisBuild := false; $1/testOnly -- xonly timefactor 3 neverstore exclude travis"
 

--- a/.travis.jvmopts
+++ b/.travis.jvmopts
@@ -3,4 +3,3 @@
 -Xmx3G
 -Xss6M
 -XX:ReservedCodeCacheSize=256M
---add-modules=java.activation

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ dist: trusty
 language: scala
 
 scala:
-  - 2.12.6
+  - 2.12.7
 
-jdk: oraclejdk9
+jdk:
+  - oraclejdk8
+  - openjdk11
 
 addons:
   apt:

--- a/common/shared/src/main/scala/org/specs2/control/Throwables.scala
+++ b/common/shared/src/main/scala/org/specs2/control/Throwables.scala
@@ -23,5 +23,6 @@ object Throwables {
   }
 
   def traceWithIndent(t: Throwable, indent: String): String =
-    trace(t).lines.map(line => indent + line).mkString("\n")
+    // Predef.augmentString = work around scala/bug#11125 on JDK 11
+    Predef.augmentString(trace(t)).lines.map(line => indent + line).mkString("\n")
 }

--- a/common/shared/src/main/scala/org/specs2/control/eff/ErrorEffect.scala
+++ b/common/shared/src/main/scala/org/specs2/control/eff/ErrorEffect.scala
@@ -207,7 +207,8 @@ object ErrorEffect extends ErrorEffect[String] {
   }
 
   def traceWithIndent(t: Throwable, indent: String): String =
-    trace(t).lines.map(line => indent + line).mkString("\n")
+    // Predef.augmentString = work around scala/bug#11125 on JDK 11
+    Predef.augmentString(trace(t)).lines.map(line => indent + line).mkString("\n")
 }
 
 case class Evaluate[F, A](run: (Throwable Either F) Either Name[A])

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.5
+sbt.version=1.2.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.23")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.25")
 addSbtPlugin("org.portable-scala" % "sbt-crossproject"         % "0.4.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.4.0")
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"                  % "1.1.1")
@@ -11,3 +11,7 @@ addSbtPlugin("ohnosequences"      % "sbt-github-release"       % "0.7.0")
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"            % "0.7.0")
 
 resolvers += Resolver.url("sonatype", new URL("https://oss.sonatype.org/content/repositories/releases"))(Resolver.ivyStylePatterns)
+
+// needed by sbt-github-release when building on JDK 11.
+// reference: https://github.com/ohnosequences/sbt-github-release/issues/28
+libraryDependencies += "com.sun.activation" % "javax.activation" % "1.2.0"


### PR DESCRIPTION
for me this is coming up in the context of trying to run the Scala 2.12 community build on JDK 11 (as well as 8, as usual)

but it's also worth having in general, I think, because your users and contributors will increasingly be on 11. (but also many will be on 8 for a while yet to come, since for now it remains the most recommended, best supported JDK for doing Scala work.)