### PR TITLE
Gracefully shut down specs2 env on exception from JUnit's `Description` creation

### DIFF
--- a/junit/shared/src/main/scala/org/specs2/runner/JUnitRunner.scala
+++ b/junit/shared/src/main/scala/org/specs2/runner/JUnitRunner.scala
@@ -12,6 +12,7 @@ import control._
 import org.specs2.fp.syntax._
 import org.specs2.concurrent.ExecutionEnv
 import ExecuteActions._
+import scala.util.control.NonFatal
 
 /**
  * Runner for specs2 specifications
@@ -35,8 +36,9 @@ class JUnitRunner(klass: Class[_]) extends org.junit.runner.Runner with Filterab
   lazy val env: Env =
     Env(arguments = arguments, lineLogger = LineLogger.consoleLogger)
 
-  lazy val getDescription =
-    JUnitDescriptions.createDescription(specStructure)(env.specs2ExecutionEnv)
+  lazy val getDescription: org.junit.runner.Description =
+    try JUnitDescriptions.createDescription(specStructure)(env.specs2ExecutionEnv)
+    catch { case NonFatal(t) => env.shutdown; throw t; }
 
   /** specification structure for the environment */
   lazy val specStructure: SpecStructure =


### PR DESCRIPTION
This PR wraps the call to `JUnitRunner.getDescription` with a try/catch, calling `env.shutdown` before rethrowing the exception. This prevent external runners (bazel, in particular) from hanging indefinitely on a crash.

Details:
The following spec causes an exception to be thrown during `getDescription`:
```
class MySpec extends mutable.Specification {
    val boom: String = { throw new RuntimeException("boom!");
}
```
This happens, unfortunately, since mutable specs must be "executed" in order to create descriptions out of them.
Some runners (bazel's, in particular), may call `getDescription` before actual test run (before any `RunNotifier` is created), to perform some filtering.
It seems that some architectural change in v4.x of specs2 caused exceptions thrown from `getDescription` to keep the external runner "waiting", until it ultimately times out. This did not happen in v3.x of specs - exceptions from `getDescription` would properly terminate the runner.

Calling `env.shutdown` before rethrowing the exception from `getDescription` seem to solve the problem of the hanging test runner.