### PR TITLE
Remove sbt-buildinfo from root project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ import sbtcrossproject.{crossProject, CrossType}
 
 /** MAIN PROJECT */
 lazy val specs2 = project.in(file(".")).
-  enablePlugins(GitBranchPrompt, SitePlugin, GhpagesPlugin, BuildInfoPlugin).
+  enablePlugins(GitBranchPrompt, SitePlugin, GhpagesPlugin).
   settings(
     moduleSettings("")  ++
     siteSettings,


### PR DESCRIPTION
The root project is only an aggregate of other projects and has no sources of its own. However, the buildinfo plugin creates one, that seems to be useless. This can have an impact on compilation time, but also confuses Hydra, and since this seems an oversight, the simplest is to remove it.