### PR TITLE
support Scala 2.13.0-RC3 (drop RC2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# needed to get oraclejdk8
+dist: trusty
+
 language: scala
 
 scala:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: scala
 scala:
   - 2.12.8
   - 2.11.12
-  - 2.13.0-RC2
+  - 2.13.0-RC3
 
 jdk:
   - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val specs2Settings = Seq(
   scalazVersion in GlobalScope := "7.2.27",
   specs2ShellPrompt,
   scalaVersion := "2.12.8",
-  crossScalaVersions := Seq(scalaVersion.value, "2.11.12", "2.13.0-RC2"))
+  crossScalaVersions := Seq(scalaVersion.value, "2.11.12", "2.13.0-RC3"))
 
 lazy val versionSettings =
   Seq(
@@ -120,7 +120,7 @@ lazy val cats = crossProject(JSPlatform, JVMPlatform).in(file("cats")).
   settings(
     moduleSettings("cats") ++
       Seq(libraryDependencies ++=
-        (if (scalaVersion.value == "2.13.0-RC2")
+        (if (scalaVersion.value == "2.13.0-RC3")
            Seq("org.typelevel" % "cats-core_2.13.0-M5" % "1.6.0",
                "org.typelevel" % "cats-effect_2.13.0-M5" % "1.2.0")
          else
@@ -384,7 +384,7 @@ lazy val compilationSettings = Seq(
         Nil
     }
   },
-  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.1"),
+  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.2"),
   scalacOptions in Test               ++= Seq("-Yrangepos"),
   scalacOptions in (Compile, doc)     ++= Seq("-feature", "-language:_"),
   scalacOptions in (Compile, console) := Seq("-Yrangepos", "-feature", "-language:_"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.27")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.28")
 addSbtPlugin("org.portable-scala" % "sbt-crossproject"         % "0.6.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"                  % "1.1.2")


### PR DESCRIPTION
note that this retains the same dodgy business as #742,
involving a 2.13.0-M5 version of cats. it's okay for now I guess
(if CI agrees)