### PR TITLE
Dotty compat: Add a Diffable instance for Nothing

### DIFF
--- a/matcher/shared/src/main/scala/org/specs2/matcher/describe/Diffable.scala
+++ b/matcher/shared/src/main/scala/org/specs2/matcher/describe/Diffable.scala
@@ -20,6 +20,10 @@ object Diffable extends DiffableLowPriority1 {
 }
 
 trait DiffableLowPriority1 extends DiffableLowPriority2 {
+  // Needed to avoid ambiguous implicits with Dotty when looking for a Diffable
+  // for `Either[Int, Nothing]` for example.
+  implicit val nothingDiffable: Diffable[Nothing] = NothingDiffable
+
   // instances for primitive types
   implicit val intDiffable    : Diffable[Int]     = primitive
   implicit val booleanDiffable: Diffable[Boolean] = primitive

--- a/matcher/shared/src/main/scala/org/specs2/matcher/describe/Diffables.scala
+++ b/matcher/shared/src/main/scala/org/specs2/matcher/describe/Diffables.scala
@@ -17,6 +17,11 @@ object PrimitiveDiffable {
 
 }
 
+object NothingDiffable extends Diffable[Nothing] {
+  def diff(actual: Nothing, expected: Nothing): Nothing =
+    throw new AssertionError(s"Critical error: attempting to compare values $actual and $expected of type Nothing, this type does not contain any value.")
+}
+
 class EitherDiffable[L : Diffable, R : Diffable]
   extends Diffable[Either[L, R]] {
 


### PR DESCRIPTION
Because Dotty is able to use Scala 2 libraries, specs2 is partially
usable from Dotty (everything but the macros should work). however the
following kind of match:

    (Left(1): Either[Int, Nothing]) must_=== Left(2)

fails with an ambiguous implicit error:

```scala
|ambiguous implicit arguments of type org.specs2.matcher.describe.Diffable[Either[Int, Nothing]] found for parameter di of method must_=== in class MustExpectable.
|I found:
|
|    org.specs2.matcher.describe.Diffable.eitherDiffable[L, R](
|      org.specs2.matcher.describe.Diffable.intDiffable
|    , /* ambiguous */implicitly[org.specs2.matcher.describe.Diffable[R]])
|
|But both getter intDiffable in trait DiffableLowPriority1 and getter stringDiffable in trait DiffableLowPriority1 match type org.specs2.matcher.describe.Diffable[R].
```

This affects ZIO which cross-compiles with Dotty and uses specs2 for its
tests, this required adding a bunch of implicits manually:
https://github.com/zio/zio/pull/674/commits/2a2d21081737871ec0fded4975671cd151798336

The root cause of the issue is that unlike in Scala 2, once a branch of
the implicit search has been marked as ambiguous, Dotty will not attempt
to find an alternative (see
http://dotty.epfl.ch/docs/reference/changed-features/implicit-resolution.html).
This means that unlike Scala 2, `fallbackDiffable[T]: Diffable[T]` will
not end up being selected.

Thankfully, we can easily resolve this ambiguity by simply adding an
instance of `Diffable` for `Nothing` (since there are no values of type
`Nothing`, the `diff` method can just throw an exception), this allows
Dotty to resolve `Diffable[Either[Int, Nothing]]` as:

    eitherDiffable(intDiffable, nothingDiffable)

Note that Scala 2 will still choose `fallbackDiffable`, probably just
because it hates instantiating a type variable to `Nothing`.