### PR TITLE
minTestsOk is minSuccessfulTests in ScalaCheck

### DIFF
--- a/guide/src/test/scala/org/specs2/guide/UseScalaCheck.scala
+++ b/guide/src/test/scala/org/specs2/guide/UseScalaCheck.scala
@@ -165,6 +165,8 @@ The parameters you can modify are:
  `seed`            | `None`                 | a Base64 encoded string which you can get from a previous failed run.
  You can set the seed on the property directly with `setSeed(string)`
 
+Note that `minTestsOk` in `specs2` corresponds to the `minSuccessfulTests` parameter in `ScalaCheck`.
+
 #### Property level
 
 It is also possible to specifically set the execution parameters on a given property: ${snippet{

--- a/scalacheck/shared/src/main/scala/org/specs2/scalacheck/Parameters.scala
+++ b/scalacheck/shared/src/main/scala/org/specs2/scalacheck/Parameters.scala
@@ -8,6 +8,8 @@ import org.scalacheck.rng.Seed
 
 /**
  * This class encapsulates ScalaCheck parameters + any additional parameters
+ *
+ * Note that minTestsOk in specs2 corresponds to the minSuccessfulTests parameter in ScalaCheck.
  */
 case class Parameters(minTestsOk: Int                 = Test.Parameters.default.minSuccessfulTests,
                       minSize: Int                    = Test.Parameters.default.minSize,


### PR DESCRIPTION
Added comments to guide and code noting that specs2 uses minTestsOk to
refer to the ScalaCheck minSuccessfulTests parameter.

See discussion in #750 