### PR TITLE
Remove quote from test of XML escape

### DIFF
--- a/junit/jvm/src/test/scala/org/specs2/reporter/JUnitXmlPrinterSpec.scala
+++ b/junit/jvm/src/test/scala/org/specs2/reporter/JUnitXmlPrinterSpec.scala
@@ -91,7 +91,7 @@ is formatted for JUnit reporting tools.
 
   object test {
     def e1 = { print(ownEnv)("t1" ^ br ^ "e1<>&\"" ! success) must \\("testcase", "classname" -> "org.specs2.reporter.JUnitXmlPrinterSpec") }
-    def e2 = { print(ownEnv)(start ^ "t1" ^ br ^ "e1<>&\"" ! success ^ end) must \\("testcase", "name" -> scala.xml.Utility.escape("t1::e1<>&\"")) }
+    def e2 = { print(ownEnv)(start ^ "t1" ^ br ^ "e1<>&" ! success ^ end) must \\("testcase", "name" -> "t1::e1&lt;&gt;&amp;") }
     def e3 = { print(ownEnv)("t1" ^ br ^ "e1<>&\"" ! success) must \\("testcase", "time") }
   }
 


### PR DESCRIPTION
The plan in scala-xml 2.0 is to stop escaping quotation marks in XML element text (attribute text will still escape quotes).

XML element text is no longer being escaped with `scala.xml.Utility.escape`.  Scala XML could probably have something added to provide parity with the two escape situations, but I'm not sure there's much value.