### PR TITLE
Allow to determine the duration before retry according the retry number

### DIFF
--- a/common/shared/src/main/scala/org/specs2/execute/EventuallyResults.scala
+++ b/common/shared/src/main/scala/org/specs2/execute/EventuallyResults.scala
@@ -13,6 +13,12 @@ trait EventuallyResults {
   /**
    * @param sleep the function applied on the retry number (first is 1)
    * @return a matcher that will retry the nested matcher a given number of times
+   *
+   * {{{
+   * eventually(retries = 2, sleep = _ * 100.milliseconds) {
+   *   aResult
+   * }
+   * }}}
    */
   def eventually[T : AsResult](retries: Int, sleep: Int => Duration)(result: =>T): T = {
     val max = retries - 1

--- a/core/jvm/src/test/scala/org/specs2/execute/EventuallyResultsSpec.scala
+++ b/core/jvm/src/test/scala/org/specs2/execute/EventuallyResultsSpec.scala
@@ -23,7 +23,6 @@ class EventuallyResultsSpec extends Specification with ResultMatchers {
     eventually(iterator.next)
   }
 
-
   "If all retries fail, the result will eventually fail" in {
     val iterator = Iterator.continually(Failure())
     eventually(iterator.next).not

--- a/matcher/shared/src/main/scala/org/specs2/matcher/EventuallyMatchers.scala
+++ b/matcher/shared/src/main/scala/org/specs2/matcher/EventuallyMatchers.scala
@@ -10,26 +10,35 @@ import org.specs2.execute.{ResultExecution, EventuallyResults}
  * This was contributed by @robey (http://robey.lag.net)
  */
 trait EventuallyMatchers extends EventuallyResults {
+  /**
+   * @param sleep the function applied on the retry number (first is 1)
+   * @return a matcher that will retry the nested matcher a given number of times
+   */
+  def eventually[T](nested: =>Matcher[T], retries: Int, sleep: Int => Duration): Matcher[T] = new Matcher[T] {
+    def apply[S <: T](a: Expectable[S]) = retry(0, a)
+
+    @annotation.tailrec
+    def retry[S <: T](retried: Int, a: Expectable[S]): MatchResult[S] = {
+      lazy val matchResult = nested(a.evaluateOnce)
+      val result = ResultExecution.execute(matchResult.toResult)
+
+      if ((result.isSuccess || retries <= 1) || retried == retries) {
+        matchResult
+      } else {
+        val pause = sleep(retried).toMillis
+        Thread.sleep(pause)
+        retry(retried + 1, a)
+      }
+    }
+  }
   
   /**
    * @return a matcher that will retry the nested matcher a given number of times
    */
-  def eventually[T](nested: =>Matcher[T], retries: Int, sleep: Duration): Matcher[T] = new Matcher[T] {
-    def apply[S <: T](a: Expectable[S]) = retry(retries, sleep, a)
-
-    def retry[S <: T](retries: Int, sleep: Duration, a: Expectable[S]): MatchResult[S] = {
-      lazy val matchResult = nested(a.evaluateOnce)
-      val result = ResultExecution.execute(matchResult.toResult)
-      if (result.isSuccess || retries <= 1)
-        matchResult
-      else {
-        Thread.sleep(sleep.toMillis)
-        retry(retries - 1, sleep, a)
-      }
-    }
-  }
+  def eventually[T](nested: =>Matcher[T], retries: Int, sleep: Duration): Matcher[T] = eventually[T](nested, retries, (_: Int) => sleep)
 
   /** @return a matcher that will retry the nested matcher 40 times  */
-  def eventually[T](nested: =>Matcher[T]): Matcher[T] = eventually(nested, 40, 100.millis)
+  def eventually[T](nested: =>Matcher[T]): Matcher[T] = eventually(nested, 40, (_: Int) => 100.millis)
 }
+
 object EventuallyMatchers extends EventuallyMatchers 

--- a/matcher/shared/src/main/scala/org/specs2/matcher/Matcher.scala
+++ b/matcher/shared/src/main/scala/org/specs2/matcher/Matcher.scala
@@ -226,6 +226,17 @@ trait Matcher[-T] { outer =>
   def eventually(retries: Int, sleep: Duration): Matcher[T] = EventuallyMatchers.eventually(this, retries, sleep)
 
   /**
+   * @param sleep the function applied on the retry number (first is 1)
+   * @return a matcher that needs to eventually match, after a given number of retries
+   * and a sleep time
+   * 
+   * {{{
+   * aResult mustEqual(expected).eventually(retries = 2, _ * 100.milliseconds)
+   * }}}
+   */
+  def eventually(retries: Int, sleep: Int => Duration): Matcher[T] = EventuallyMatchers.eventually(this, retries, sleep)
+
+  /**
    * @return a Matcher with no messages
    */
   def mute = setMessage("")

--- a/matcher/shared/src/main/scala/org/specs2/matcher/Matcher.scala
+++ b/matcher/shared/src/main/scala/org/specs2/matcher/Matcher.scala
@@ -218,6 +218,7 @@ trait Matcher[-T] { outer =>
    * of 100 milliseconds
    */
   def eventually: Matcher[T] = EventuallyMatchers.eventually(this)
+
   /**
    * @return a matcher that needs to eventually match, after a given number of retries
    * and a sleep time


### PR DESCRIPTION
Usage:

```scala
eventually(retries = 3, _ * 100.milliseconds) {
  ???
}

foo must beTrue.eventually(3, _ * 75.milliseconds + 1.second)
```