### PR TITLE
fix #757

### DIFF
--- a/common/jvm/src/main/scala/org/specs2/reflect/Classes.scala
+++ b/common/jvm/src/main/scala/org/specs2/reflect/Classes.scala
@@ -1,7 +1,7 @@
 package org.specs2
 package reflect
 
-import scala.reflect.ClassTag
+import scala.reflect.{ClassTag, NameTransformer}
 import ClassName._
 import control._
 import scala.util.control.NonFatal
@@ -70,9 +70,13 @@ trait Classes extends ClassOperations {
                                                                    defaultInstances: =>List[AnyRef]): Operation[T] = {
 
     constructor.setAccessible(true)
-    if (constructor.getParameterTypes.isEmpty)
-      newInstance(klass, constructor.newInstance())
-
+    if (constructor.getParameterTypes.isEmpty) {
+      if (klass.getName.endsWith("$")) {
+        newInstance(klass, klass.getDeclaredField(NameTransformer.MODULE_INSTANCE_NAME).get(null))
+      } else {
+        newInstance(klass, constructor.newInstance())
+      }
+    }
     else if (constructor.getParameterTypes.size == 1) {
       defaultInstances.find(i => constructor.getParameterTypes.apply(0) isAssignableFrom i.getClass) match {
         case None =>


### PR DESCRIPTION
fix #757

maybe https://github.com/scala/scala/pull/7270 ? 🤔 

```scala
package example

import scala.reflect.NameTransformer

object A{
  Main.a = 1
}

object B{
  Main.b = 1
}

object Main {
  var a: Int = 0
  var b: Int = 0

  def initializeByConstructor(): Int = {
    this.a = 0
    val List(constructor) = Class.forName("example.A$").getDeclaredConstructors.toList
    constructor.setAccessible(true)
    constructor.newInstance()
    val result = Main.a
    this.a = 0
    result
  }

  def initializeByMODULE_field(): Int = {
    this.b = 0
    Class.forName("example.B$").getDeclaredField(NameTransformer.MODULE_INSTANCE_NAME).get(null)
    val result = Main.b
    this.b = 0
    result
  }

  def main(args: Array[String]): Unit = {
    println((A, B))
    println(scala.util.Properties.versionString)
    println(initializeByConstructor())
    println(initializeByMODULE_field())
  }
}
```

```
[info] version 2.12.11
[info] 1
[info] 0
```

```
[info] version 2.13.2
[info] 0
[info] 0
```