### PR TITLE
Try matcher fails with instance of Exception trait

### DIFF
--- a/matcher/shared/src/main/scala/org/specs2/matcher/TryMatchers.scala
+++ b/matcher/shared/src/main/scala/org/specs2/matcher/TryMatchers.scala
@@ -72,7 +72,7 @@ case class TryFailureMatcher[T]() extends OptionLikeMatcher[Try, T, Throwable]("
   })
 
   def withThrowable[E <: Throwable : ClassTag](pattern: String) = TryFailureCheckedMatcher[T](ValueChecks.functionIsValueCheck { t: Throwable =>
-    (createExpectable(t).applyMatcher(AnyMatchers.haveClass[E]) and
+    (createExpectable(t).applyMatcher(AnyMatchers.beAnInstanceOf[E]) and
      createExpectable(t.getMessage.notNull).applyMatcher(StringMatchers.beMatching(pattern))).toResult
   })
 }

--- a/tests/src/test/scala/org/specs2/matcher/TryMatchersSpec.scala
+++ b/tests/src/test/scala/org/specs2/matcher/TryMatchersSpec.scala
@@ -40,7 +40,8 @@ class TryMatchersSpec extends Spec with TryMatchers with ResultMatchers { def is
   ${ Failed[I](e) must not be aFailedTry.withThrowable[MyException]("bang") }
   ${ (Failed[I](e) must beAFailedTry.withThrowable[MyException]("bang")) returns "Failure(boom) is a Failure but 'boom' doesn't match 'bang'" }
   ${ Failed[I](e) must not be aFailedTry.withThrowable[OtherException] }
-
+  ${ Failed[I](ExceptionTrait("bang")) must beFailedTry.withThrowable[ExceptionTrait] }
+  ${ Failed[I](ExceptionTrait("bang")) must beFailedTry.withThrowable[ExceptionTrait]("bang") }
   """
 
   val e = new MyException("boom")
@@ -53,4 +54,11 @@ class TryMatchersSpec extends Spec with TryMatchers with ResultMatchers { def is
   }
   class OtherException extends Exception
   type I = Int
+
+  trait ExceptionTrait extends Exception
+  object ExceptionTrait {
+    def apply(message: String): ExceptionTrait = new ExceptionTrait {
+      override def getMessage: String = message
+    }
+  }
 }


### PR DESCRIPTION
When `Try` is handling an `Throwable` instanciated [from an anonymous subtype](https://github.com/etorreborre/specs2/pull/836/files#diff-aa179e2655318cda8e068701336d0888R58), matcher `beFailed.withThrowable[..](pattern)` is failing (due to the use of `haveClass` instead of `beAnInstanceOf`, as for the matcher `beFailed.withThrowable[..]` without message pattern).

See [test failing before](https://github.com/etorreborre/specs2/pull/836/files#diff-aa179e2655318cda8e068701336d0888R44): [Test result](https://travis-ci.org/github/etorreborre/specs2/jobs/702511734#L771)

