### PR TITLE
Fix catching unsupported step methods from IntelliJ

### DIFF
--- a/core/shared/src/main/scala/org/specs2/reporter/NotifierPrinter.scala
+++ b/core/shared/src/main/scala/org/specs2/reporter/NotifierPrinter.scala
@@ -125,7 +125,7 @@ object NotifierPrinter {
       // catch AbstractMethod errors coming from Intellij since
       // calling new "step" methods on the Notifier interface is not supported yet
     } catch {
-      case e: AbstractMethodError if e.getMessage.notNull.contains("JavaSpecs2Notifier") =>
+      case e: AbstractMethodError if e.getMessage.notNull.contains("Specs2Notifier") =>
         // if steps are not supported print failures and errors as examples failures and errors
         executedResult.result match {
           case r: execute.Failure =>


### PR DESCRIPTION
IntelliJ has removed the Java prefix from their `Specs2Notifier` class.
https://github.com/JetBrains/intellij-scala/commit/d75e0c0e834dff9585e1cb0ced6d04e5c27248d3#diff-93cd505918cbca67189c8abea10d705aR19