### PR TITLE
Depend on hamcrest instead of hamcrest-core which is deprecated

### DIFF
--- a/project/depends.scala
+++ b/project/depends.scala
@@ -49,7 +49,7 @@ object depends {
 
   lazy val mockito  = "org.mockito"  % "mockito-core"  % "3.7.7"
   lazy val junit    = "junit"        % "junit"         % "4.13.2"
-  lazy val hamcrest = "org.hamcrest" % "hamcrest-core" % "2.2"
+  lazy val hamcrest = "org.hamcrest" % "hamcrest" % "2.2"
 
   lazy val pegdown = "org.pegdown" % "pegdown" % "1.6.0"
 


### PR DESCRIPTION
`org.hamcrest:hamcrest-core:2.2` has been deprecated and is an empty jar. For backwards compatibility `hamcrest-core` transitively brings `org.hamcrest:hamcrest:2.2`, which should be used instead.