### PR TITLE
Upgrade kind-projector, replace deprecated `?` syntax

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -445,7 +445,7 @@ lazy val compilationSettings = Seq(
           "-Xlint:-byname-implicit")
     }
   },
-  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"),
+  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.0" cross CrossVersion.full),
   Test / scalacOptions += "-Yrangepos",
   Compile / doc / scalacOptions ++= Seq("-feature", "-language:_"),
   Compile / console / scalacOptions := Seq("-Yrangepos", "-feature", "-language:_"),

--- a/common/shared/src/main/scala/org/specs2/control/eff/Eff.scala
+++ b/common/shared/src/main/scala/org/specs2/control/eff/Eff.scala
@@ -136,9 +136,9 @@ object Eff extends EffCreation with
 trait EffImplicits {
 
   /**
-   * Monad implementation for the Eff[R, ?] type
+   * Monad implementation for the Eff[R, *] type
    */
-  implicit final def EffMonad[R]: Monad[Eff[R, ?]] = new Monad[Eff[R, ?]] {
+  implicit final def EffMonad[R]: Monad[Eff[R, *]] = new Monad[Eff[R, *]] {
     def point[A](a: =>A): Eff[R, A] =
       Pure(a)
 
@@ -170,7 +170,7 @@ trait EffImplicits {
       }
   }
 
-  def EffApplicative[R]: Applicative[Eff[R, ?]] = new Applicative[Eff[R, ?]] {
+  def EffApplicative[R]: Applicative[Eff[R, *]] = new Applicative[Eff[R, *]] {
     def point[A](a: =>A): Eff[R, A] =
       Pure(a)
 
@@ -200,8 +200,8 @@ trait EffImplicits {
       }
   }
 
-  implicit def naturalInto[R, U](into: IntoPoly[R, U]): Eff[R, ?] ~> Eff[U, ?] =
-    new (Eff[R, ?] ~> Eff[U, ?]) {
+  implicit def naturalInto[R, U](into: IntoPoly[R, U]): Eff[R, *] ~> Eff[U, *] =
+    new (Eff[R, *] ~> Eff[U, *]) {
       def apply[A](e: Eff[R, A]): Eff[U, A] = into(e)
     }
 

--- a/common/shared/src/main/scala/org/specs2/control/eff/ErrorEffect.scala
+++ b/common/shared/src/main/scala/org/specs2/control/eff/ErrorEffect.scala
@@ -169,13 +169,13 @@ trait ErrorInterpretation[F] extends ErrorCreation[F] { outer =>
    * a computation over a "bigger" error (for the full application)
    */
   def runLocalError[R, U, F1, F2, A](r: Eff[R, A], getter: F1 => F2)
-                                    (implicit sr: Member.Aux[Evaluate[F1, ?], R, U], br: Evaluate[F2, ?] |= U): Eff[U, A] =
-  translate[R, U, Evaluate[F1, ?], A](r) { new Translate[Evaluate[F1, ?], U] {
+                                    (implicit sr: Member.Aux[Evaluate[F1, *], R, U], br: Evaluate[F2, *] |= U): Eff[U, A] =
+  translate[R, U, Evaluate[F1, *], A](r) { new Translate[Evaluate[F1, *], U] {
     def apply[X](ex: Evaluate[F1, X]): Eff[U, X] =
       ex.run match {
-        case Left(Left(t))  => send[Evaluate[F2, ?], U, X](Evaluate.exception[F2, X](t))
-        case Left(Right(e1)) => send[Evaluate[F2, ?], U, X](Evaluate.fail[F2, X](getter(e1)))
-        case Right(x)       => send[Evaluate[F2, ?], U, X](Evaluate.eval[F2, X](x))
+        case Left(Left(t))  => send[Evaluate[F2, *], U, X](Evaluate.exception[F2, X](t))
+        case Left(Right(e1)) => send[Evaluate[F2, *], U, X](Evaluate.fail[F2, X](getter(e1)))
+        case Right(x)       => send[Evaluate[F2, *], U, X](Evaluate.eval[F2, X](x))
       }
   }}
 

--- a/common/shared/src/main/scala/org/specs2/control/eff/FutureEffect.scala
+++ b/common/shared/src/main/scala/org/specs2/control/eff/FutureEffect.scala
@@ -130,8 +130,8 @@ trait FutureInterpretation extends FutureTypes {
   import interpret.of
 
   final def futureAttempt[R, A](e: Eff[R, A])(implicit future: TimedFuture /= R): Eff[R, Throwable Either A] =
-    interpret.interceptNatM[R, TimedFuture, Throwable Either ?, A](e,
-      new (TimedFuture ~> (TimedFuture of (Throwable Either ?))#l) {
+    interpret.interceptNatM[R, TimedFuture, Throwable Either *, A](e,
+      new (TimedFuture ~> (TimedFuture of (Throwable Either *))#l) {
         override def apply[X](fa: TimedFuture[X]): TimedFuture[Throwable Either X] = fa.attempt
       })
 

--- a/common/shared/src/main/scala/org/specs2/control/eff/Interpret.scala
+++ b/common/shared/src/main/scala/org/specs2/control/eff/Interpret.scala
@@ -476,7 +476,7 @@ trait Interpret {
    * Using a natural transformation
    */
   def translateNat[R, U, T[_], A](effects: Eff[R, A])
-                                 (nat: T ~> Eff[U, ?])
+                                 (nat: T ~> Eff[U, *])
                                  (implicit m: Member.Aux[T, R, U]): Eff[U, A] =
   translate(effects)(new Translate[T, U] {
     def apply[X](tx: T[X]): Eff[U, X] = nat(tx)

--- a/common/shared/src/main/scala/org/specs2/control/eff/syntax/disjunction.scala
+++ b/common/shared/src/main/scala/org/specs2/control/eff/syntax/disjunction.scala
@@ -8,16 +8,16 @@ trait disjunction {
 
   implicit class DisjunctionEffectOps[R, A](e: Eff[R, A]) {
 
-    def runDisjunction[E, U](implicit m: Member.Aux[(E Either ?), R, U]): Eff[U, E Either A] =
+    def runDisjunction[E, U](implicit m: Member.Aux[(E Either *), R, U]): Eff[U, E Either A] =
       DisjunctionInterpretation.runDisjunction(e)(m)
 
-    def runEither[E, U](implicit m: Member.Aux[(E Either ?), R, U]): Eff[U, E Either A] =
+    def runEither[E, U](implicit m: Member.Aux[(E Either *), R, U]): Eff[U, E Either A] =
       DisjunctionInterpretation.runEither(e)(m)
 
-    def catchLeft[E](handle: E => Eff[R, A])(implicit member: Member[(E Either ?), R]): Eff[R, A] =
+    def catchLeft[E](handle: E => Eff[R, A])(implicit member: Member[(E Either *), R]): Eff[R, A] =
       DisjunctionInterpretation.catchLeft(e)(handle)(member)
 
-    def runLocalDisjunction[U, C, B](getter: C => B)(implicit sr: Member.Aux[C Either ?, R, U], br: (B Either ?) |= U): Eff[U, A] =
+    def runLocalDisjunction[U, C, B](getter: C => B)(implicit sr: Member.Aux[C Either *, R, U], br: (B Either *) |= U): Eff[U, A] =
       DisjunctionInterpretation.runLocalDisjunction[R, U, C, B, A](e, getter)
 
   }

--- a/common/shared/src/main/scala/org/specs2/control/eff/syntax/writer.scala
+++ b/common/shared/src/main/scala/org/specs2/control/eff/syntax/writer.scala
@@ -10,19 +10,19 @@ trait writer {
 
   implicit class WriterEffectOps[R, A](e: Eff[R, A]) {
 
-    def runWriter[O](implicit member: Member[Writer[O, ?], R]): Eff[member.Out, (A, List[O])] =
+    def runWriter[O](implicit member: Member[Writer[O, *], R]): Eff[member.Out, (A, List[O])] =
       WriterInterpretation.runWriter(e)(member.aux)
 
-    def runWriterNoLog[O](implicit member: Member[Writer[O, ?], R]): Eff[member.Out, A] =
+    def runWriterNoLog[O](implicit member: Member[Writer[O, *], R]): Eff[member.Out, A] =
       runWriter[O](member).map(_._1)
 
-    def runWriterLog[O](implicit member: Member[Writer[O, ?], R]): Eff[member.Out, List[O]] =
+    def runWriterLog[O](implicit member: Member[Writer[O, *], R]): Eff[member.Out, List[O]] =
       runWriter[O](member).map(_._2)
 
-    def runWriterFold[O, B](fold: FoldId[O, B])(implicit member: Member[Writer[O, ?], R]): Eff[member.Out, (A, B)] =
+    def runWriterFold[O, B](fold: FoldId[O, B])(implicit member: Member[Writer[O, *], R]): Eff[member.Out, (A, B)] =
       WriterInterpretation.runWriterFold(e)(fold)(member.aux)
 
-    def runWriterUnsafe[O](f: O => Unit)(implicit member: Member[Writer[O, ?], R]): Eff[member.Out, A] =
+    def runWriterUnsafe[O](f: O => Unit)(implicit member: Member[Writer[O, *], R]): Eff[member.Out, A] =
       WriterInterpretation.runWriterUnsafe(e)(f)(member.aux)
 
   }

--- a/common/shared/src/main/scala/org/specs2/control/origami/Fold.scala
+++ b/common/shared/src/main/scala/org/specs2/control/origami/Fold.scala
@@ -281,7 +281,7 @@ object Fold {
    *
    *   val meanTimes2 = mean.map(_ * 2)
    */
-  implicit def ApplicativeFold[M[_] : Monad, T]: Applicative[Fold[M, T, ?]] = new Applicative[Fold[M, T, ?]] {
+  implicit def ApplicativeFold[M[_] : Monad, T]: Applicative[Fold[M, T, *]] = new Applicative[Fold[M, T, *]] {
     type F[U] = Fold[M, T, U]
 
     def point[A](a: =>A): Fold[M, T, A] =
@@ -337,9 +337,9 @@ trait Folds {
     def end(s: S) = monad.point(s)
   }
 
-  def bracket[R :_Safe, A, C](open: Eff[R, C])(step: (C, A) => Eff[R, C])(close: C => Eff[R, Unit]): Fold[Eff[R, ?], A, Unit] = new Fold[Eff[R, ?], A, Unit] {
+  def bracket[R :_Safe, A, C](open: Eff[R, C])(step: (C, A) => Eff[R, C])(close: C => Eff[R, Unit]): Fold[Eff[R, *], A, Unit] = new Fold[Eff[R, *], A, Unit] {
     type S = C
-    val monad: Monad[Eff[R, ?]] = Monad[Eff[R, ?]]
+    val monad: Monad[Eff[R, *]] = Monad[Eff[R, *]]
 
     def start = open
     def fold = (s: S, a: A) => otherwise(step(s, a), close(s).as(s))

--- a/common/shared/src/main/scala/org/specs2/control/origami/package.scala
+++ b/common/shared/src/main/scala/org/specs2/control/origami/package.scala
@@ -18,10 +18,10 @@ package object origami {
   type Sink[M[_], A] = Fold[M, A, Unit]
 
   /** alias for a Fold sinking its last value */
-  type SinkEff[R, A] = Fold[Eff[R, ?], A, Unit]
+  type SinkEff[R, A] = Fold[Eff[R, *], A, Unit]
 
   /** alias for a Fold exposing it state type */
-  type Aux[R, A, B, S1] = Fold[Eff[R, ?], A, B] { type S = S1 }
+  type Aux[R, A, B, S1] = Fold[Eff[R, *], A, B] { type S = S1 }
 
 }
 

--- a/common/shared/src/main/scala/org/specs2/control/producer/Producer.scala
+++ b/common/shared/src/main/scala/org/specs2/control/producer/Producer.scala
@@ -82,7 +82,7 @@ object Producer extends Producers {
       p1 append p2
   }
 
-  implicit def FoldableProducer: Foldable[Producer[NoFx, ?]] = new Foldable[Producer[NoFx, ?]] {
+  implicit def FoldableProducer: Foldable[Producer[NoFx, *]] = new Foldable[Producer[NoFx, *]] {
     override def foldLeft[A, B](fa: Producer[NoFx, A], b: B)(f: (B, A) => B): B = {
       var s = b
       fa.run.run match {
@@ -111,7 +111,7 @@ object Producer extends Producers {
 
   }
 
-  implicit def ProducerMonad[R :_Safe]: Monad[Producer[R, ?]] = new Monad[Producer[R, ?]] {
+  implicit def ProducerMonad[R :_Safe]: Monad[Producer[R, *]] = new Monad[Producer[R, *]] {
     def bind[A, B](fa: Producer[R, A])(f: A => Producer[R, B]): Producer[R, B] =
       fa.flatMap(f)
 
@@ -216,7 +216,7 @@ trait Producers {
   def runList[R :_Safe, A](producer: Producer[R, A]): Eff[R, List[A]] =
     producer.fold(pure(Vector[A]()), (vs: Vector[A], a: A) => pure(vs :+ a), (vs:Vector[A]) => pure(vs.toList))
 
-  def collect[R :_Safe, A](producer: Producer[R, A])(implicit m: Member[Writer[A, ?], R]): Eff[R, Unit] =
+  def collect[R :_Safe, A](producer: Producer[R, A])(implicit m: Member[Writer[A, *], R]): Eff[R, Unit] =
     producer.run flatMap {
       case Done() => pure(())
       case One(a) => tell(a)

--- a/common/shared/src/main/scala/org/specs2/control/producer/package.scala
+++ b/common/shared/src/main/scala/org/specs2/control/producer/package.scala
@@ -39,7 +39,7 @@ package object producer {
     def fold[B, S](start: Eff[R, S], f: (S, A) => Eff[R, S], end: S => Eff[R, B]): Eff[R, B] =
       Producer.fold(p)(start, f, end)
 
-    def fold[S, B](f: Fold[Eff[R, ?], A, B]): Eff[R, B] =
+    def fold[S, B](f: Fold[Eff[R, *], A, B]): Eff[R, B] =
       Producer.fold(p)(f.start, f.fold, f.end)
 
     def observe[S](start: Eff[R, S], f: (S, A) => S, end: S => Eff[R, Unit]): Producer[R, A] =

--- a/common/shared/src/main/scala/org/specs2/io/Fold.scala
+++ b/common/shared/src/main/scala/org/specs2/io/Fold.scala
@@ -13,7 +13,7 @@ import org.specs2.control.eff.Eff
 object FoldIo {
 
   /** create a fold sink to output lines to a file */
-  def showToFilePath[R :_Safe, T : Show](path: FilePath): Sink[Eff[R, ?], T] =
+  def showToFilePath[R :_Safe, T : Show](path: FilePath): Sink[Eff[R, *], T] =
     printToFilePath(path)(t => Eff.pure(Show[T].show(t)))
 
   /** create a fold sink to output lines to a file */

--- a/fp/shared/src/main/scala/org/specs2/fp/Applicative.scala
+++ b/fp/shared/src/main/scala/org/specs2/fp/Applicative.scala
@@ -127,7 +127,7 @@ object Applicative {
   implicit def optionApplicative[L]: Applicative[Option] =
     Monad.optionMonad
 
-  implicit def eitherApplicative[L]: Applicative[Either[L, ?]] =
+  implicit def eitherApplicative[L]: Applicative[Either[L, *]] =
     Monad.eitherMonad[L]
 
   implicit def futureApplicative(implicit ec: ExecutionContext): Applicative[Future] =

--- a/fp/shared/src/main/scala/org/specs2/fp/Monad.scala
+++ b/fp/shared/src/main/scala/org/specs2/fp/Monad.scala
@@ -67,7 +67,7 @@ object Monad {
       }
   }
 
-  implicit def eitherMonad[L]: Monad[Either[L, ?]] = new Monad[Either[L, ?]] {
+  implicit def eitherMonad[L]: Monad[Either[L, *]] = new Monad[Either[L, *]] {
     def point[A](a: =>A): Either[L, A] = Right(a)
 
     def bind[A,B](fa: Either[L, A])(f: A => Either[L, B]): Either[L, B] =

--- a/fp/shared/src/main/scala/org/specs2/fp/Traverse.scala
+++ b/fp/shared/src/main/scala/org/specs2/fp/Traverse.scala
@@ -56,7 +56,7 @@ object Traverse {
       fa.map(f)
   }
 
-  implicit def eitherInstance[L]: Traverse[Either[L, ?]] = new Traverse[Either[L, ?]] {
+  implicit def eitherInstance[L]: Traverse[Either[L, *]] = new Traverse[Either[L, *]] {
     def traverseImpl[G[_]: Applicative, A, B](fa: Either[L, A])(f: A => G[B]): G[Either[L, B]] = {
       val g = Applicative.apply[G]
       fa match {


### PR DESCRIPTION
The `?` syntax in types was deprecated and removed from kind-projector
in favor of `*`. `?` is reused for wildcards in Scala 3 as well as Scala
2 under `-Xsource:3`, and this meaning might also be supported by
default in a future version of Scala 2. See
http://dotty.epfl.ch/docs/reference/changed-features/wildcards.html for
more information.