### PR TITLE
Upgrade scala-xml to 2.0.1 for next 4.12.x release

### DIFF
--- a/project/depends.scala
+++ b/project/depends.scala
@@ -44,7 +44,7 @@ object depends {
       scalaParser.value
   }
 
-  def scalaXml = "org.scala-lang.modules" %% "scala-xml" % "1.3.0"
+  def scalaXml = "org.scala-lang.modules" %% "scala-xml" % "2.0.1"
 
   lazy val mockito  = "org.mockito"  % "mockito-core"  % "3.11.2"
   lazy val junit    = "junit"        % "junit"         % "4.13.2"


### PR DESCRIPTION
@etorreborre What was the reason you reverted to scala-xml 1.3.0 here: https://github.com/etorreborre/specs2/commit/eee7bea1f81333d9c3561614fcd4e85b53a8383e?