### PR TITLE
Regression when using .pendingUntilFixed + BeforeAll

### DIFF
--- a/core/jvm/src/test/scala/org/specs2/execute/PendingUntilFixedBeforeAllSpec.scala
+++ b/core/jvm/src/test/scala/org/specs2/execute/PendingUntilFixedBeforeAllSpec.scala
@@ -13,6 +13,6 @@ class PendingUntilFixedBeforeAllSpec extends Specification with BeforeAll {
 
   "Pending until fixed can be used with BeforeAll" >> {
     setupFinished ==== true
-    (1 ==== 1).pendingUntilFixed("Will explode")
+    (1 ==== 2).pendingUntilFixed("Will explode")
   }
 }

--- a/core/jvm/src/test/scala/org/specs2/execute/PendingUntilFixedBeforeAllSpec.scala
+++ b/core/jvm/src/test/scala/org/specs2/execute/PendingUntilFixedBeforeAllSpec.scala
@@ -1,0 +1,18 @@
+package org.specs2
+package execute
+
+import org.specs2.mutable.Specification
+import org.specs2.specification.BeforeAll
+
+class PendingUntilFixedBeforeAllSpec extends Specification with BeforeAll {
+  private[this] var setupFinished = false
+
+  override def beforeAll(): Unit = {
+    setupFinished = true // will not execute as of 4.12.4
+  }
+
+  "Pending until fixed can be used with BeforeAll" >> {
+    setupFinished ==== true
+    (1 ==== 1).pendingUntilFixed("Will explode")
+  }
+}


### PR DESCRIPTION
A reproducible example on something that's exploding our tests since we upgraded from 4.12.3
Tests that use .pendingUntilFixed and BeforeAll regress with Specs2 exploding on what seems to be valid code

    [error] cannot create an instance for class ExampleSpec
    [error]   caused by org.specs2.matcher.MatchFailureException: false != true
    [error]   caused by java.lang.Exception: false != true
    [error]   java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)

Specs2 versions from 4.12.4 to 4.12.6 are affected