### PR TITLE
Make ExecutionEnv consistent across JVM/JS

### DIFF
--- a/common/js/src/main/scala/org/specs2/concurrent/ExecutionEnvPlatform.scala
+++ b/common/js/src/main/scala/org/specs2/concurrent/ExecutionEnvPlatform.scala
@@ -5,19 +5,7 @@ import org.specs2.control.Logger
 import org.specs2.main.Arguments
 import scala.concurrent.*, duration.*
 
-/** Execution environment for javascript
-  */
-case class ExecutionEnv(executorServices: ExecutorServices, timeFactor: Int):
-
-  def shutdown(): Unit = ()
-
-  given executionContext: ExecutionContext = executorServices.executionContext
-  given ec: ExecutionContext = executionContext
-
-  def schedule(action: =>Unit, duration: FiniteDuration): Unit =
-    executorServices.schedule(action, duration)
-
-object ExecutionEnv:
+private[concurrent] trait ExecutionEnvCompanionPlatform:
 
   def create(arguments: Arguments, systemLogger: Logger, tag: Option[String] = None): ExecutionEnv =
     createSpecs2(arguments, systemLogger, tag)

--- a/common/jvm/src/main/scala/org/specs2/concurrent/ExecutionEnvPlatform.scala
+++ b/common/jvm/src/main/scala/org/specs2/concurrent/ExecutionEnvPlatform.scala
@@ -6,20 +6,7 @@ import org.specs2.main.Arguments
 
 import scala.concurrent.ExecutionContext
 
-/** Execution environment for javascript
-  */
-case class ExecutionEnv(executorServices: ExecutorServices, timeFactor: Int) {
-
-  def shutdown(): Unit = ()
-
-  given executionContext: ExecutionContext = executorServices.executionContext
-  given ec: ExecutionContext = executorServices.executionContext
-
-  lazy val scheduler = executorServices.scheduler
-
-}
-
-object ExecutionEnv:
+private[concurrent] trait ExecutionEnvCompanionPlatform:
 
   /** create an ExecutionEnv from an execution context only */
   def fromExecutionContext(ec: =>ExecutionContext): ExecutionEnv =

--- a/common/shared/src/main/scala/org/specs2/concurrent/ExecutionEnv.scala
+++ b/common/shared/src/main/scala/org/specs2/concurrent/ExecutionEnv.scala
@@ -1,0 +1,23 @@
+package org.specs2
+package concurrent
+
+import org.specs2.control.Logger
+import org.specs2.main.Arguments
+
+import scala.concurrent.*, duration.*
+
+/** Execution environment
+  */
+case class ExecutionEnv(executorServices: ExecutorServices, timeFactor: Int):
+
+  def shutdown(): Unit = ()
+
+  given executionContext: ExecutionContext = executorServices.executionContext
+  given ec: ExecutionContext = executorServices.executionContext
+
+  lazy val scheduler = executorServices.scheduler
+
+  def schedule(action: =>Unit, duration: FiniteDuration): Unit =
+    executorServices.schedule(action, duration)
+
+object ExecutionEnv extends ExecutionEnvCompanionPlatform


### PR DESCRIPTION
This makes the `ExecutionEnv` API consistent across JVM and JS. Came up while working on https://github.com/etorreborre/specs2-cats/pull/4.