### PR TITLE
Update `scala-js-macrotask-executor` to version 1.0.0

### DIFF
--- a/project/depends.scala
+++ b/project/depends.scala
@@ -32,7 +32,7 @@ object depends {
         Test / scalaJSStage := FastOptStage)
 
   def jsMacrotaskExecutor =
-    Seq(libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % "0.1.0")
+    Seq(libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % "1.0.0")
 
   def nativeTest =
     Seq(libraryDependencies += "org.scala-native" %%% "test-interface" % nativeVersion)


### PR DESCRIPTION
A corresponding release would be very much appreciated.