### PR TITLE
Remove bad trailing comma

### DIFF
--- a/core/shared/src/main/scala/org/specs2/matcher/ActionMatchers.scala
+++ b/core/shared/src/main/scala/org/specs2/matcher/ActionMatchers.scala
@@ -32,7 +32,7 @@ trait ActionMatchers extends ValueChecks:
     FutureMatcher { (action: Action[T]) =>
       action.runFuture(executionEnv).map(_ => Failure(s"a failure with message $message was expected")).recover {
         case t if t.getMessage `matchesSafely` message => Success("ok")
-        case t => Failure(s"the action failed with message ${t.getMessage}. Expected: $message"),
+        case t => Failure(s"the action failed with message ${t.getMessage}. Expected: $message")
       }
     }
 


### PR DESCRIPTION
There is a [PR](https://github.com/lampepfl/dotty/pull/14517) up to remove bad trailing commas from dotty. This bad trailing comma is breaking the community build.