### PR TITLE
Upgrade scala-xml to 2.1.0 for next 4.17 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.16]
+        scala: [2.13.8, 2.12.17]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.16]
+        scala: [2.13.8]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.17]
+        scala: [2.12.16]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.17]
+        scala: [2.12.16]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.15]
+        scala: [2.12.17]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.15]
+        scala: [2.12.17]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -33,9 +33,9 @@ lazy val specs2Settings = Seq(
   organization := "org.specs2",
   GlobalScope / scalazVersion := "7.2.32",
   specs2ShellPrompt,
-  scalaVersion := "2.13.8",
+  ThisBuild / scalaVersion := "2.13.8",
   SettingKey[Boolean]("ide-skip-project").withRank(KeyRanks.Invisible) := platformDepsCrossVersion.value == ScalaNativeCrossVersion.binary,
-  crossScalaVersions := Seq(scalaVersion.value, "2.12.16"))
+  ThisBuild / crossScalaVersions := Seq(scalaVersion.value, "2.12.17"))
 
 lazy val tagName = Def.setting {
   s"specs2-${version.value}"

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val specs2Settings = Seq(
   specs2ShellPrompt,
   ThisBuild / scalaVersion := "2.13.8",
   SettingKey[Boolean]("ide-skip-project").withRank(KeyRanks.Invisible) := platformDepsCrossVersion.value == ScalaNativeCrossVersion.binary,
-  ThisBuild / crossScalaVersions := Seq(scalaVersion.value, "2.12.17"))
+  ThisBuild / crossScalaVersions := Seq("2.13.8", "2.12.17"))
 
 lazy val tagName = Def.setting {
   s"specs2-${version.value}"

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val specs2Settings = Seq(
   specs2ShellPrompt,
   scalaVersion := "2.13.8",
   SettingKey[Boolean]("ide-skip-project").withRank(KeyRanks.Invisible) := platformDepsCrossVersion.value == ScalaNativeCrossVersion.binary,
-  crossScalaVersions := Seq(scalaVersion.value, "2.12.17"))
+  crossScalaVersions := Seq(scalaVersion.value, "2.12.16"))
 
 lazy val tagName = Def.setting {
   s"specs2-${version.value}"

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val specs2Settings = Seq(
   specs2ShellPrompt,
   scalaVersion := "2.13.8",
   SettingKey[Boolean]("ide-skip-project").withRank(KeyRanks.Invisible) := platformDepsCrossVersion.value == ScalaNativeCrossVersion.binary,
-  crossScalaVersions := Seq(scalaVersion.value, "2.12.15"))
+  crossScalaVersions := Seq(scalaVersion.value, "2.12.17"))
 
 lazy val tagName = Def.setting {
   s"specs2-${version.value}"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.1

--- a/project/depends.scala
+++ b/project/depends.scala
@@ -47,7 +47,7 @@ object depends {
     Seq("org.scala-lang.modules" %%% "scala-parser-combinators" % "2.1.0")
   }
 
-  def scalaXml = "org.scala-lang.modules" %% "scala-xml" % "1.3.0"
+  def scalaXml = "org.scala-lang.modules" %% "scala-xml" % "2.1.0"
 
   lazy val mockito  = "org.mockito"  % "mockito-core"  % "3.11.2"
   lazy val junit    = "junit"        % "junit"         % "4.13.2"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 val scalaJSVersion =
-Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.7.0")
+Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.7.1")
 val scalaNativeVersion =
 Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.4.3")
 


### PR DESCRIPTION
I know once you already upgraded to scala-xml for 4.x, but [later reverted that again](https://github.com/etorreborre/specs2/commit/eee7bea1f81333d9c3561614fcd4e85b53a8383e), we also had [a discussion](https://github.com/etorreborre/specs2/pull/979).

However, the Scala world is moving towards scala-xml 2.x, even for current stable releases
* Scala 2.12.17 upgraded to scala-xml 2.1.0: https://github.com/scala/scala/pull/10108
* The next sbt version will then come with Scala 2.12.17: https://github.com/sbt/sbt/pull/7021
* sbt-native packager upgraded in its 1.9.10 (patch) release: https://github.com/sbt/sbt-native-packager/pull/1514
* More libraries are upgrading: https://github.com/sbt/sbt-native-packager/issues/1513
* I am in the processing of upgrading libraries I am maintaining, e.g. https://github.com/playframework/twirl/pull/547