### PR TITLE
Fix links to ScalaDocs and example code

### DIFF
--- a/website/SPECS2-5.0.7/learn.html
+++ b/website/SPECS2-5.0.7/learn.html
@@ -32,8 +32,8 @@ There are various sources you can use to learn about <s2>specs2</s2>
       <ul>
       <li>the <a href="https://etorreborre.github.io/specs2/guide/SPECS2-5.0.7/org.specs2.guide.UserGuide.html">User Guide</a>. In particular you can start by learning how to <a href="https://etorreborre.github.io/specs2/guide/SPECS2-5.0.7/org.specs2.guide.Structure.html">structure</a> your specification
       </li>
-      <li>the <a href="https://etorreborre.github.io/specs2/api/SPECS2-5.0.7/api/index.html">ScalaDoc</a></li>
-      <li>the <a href="https://github.com/etorreborre/specs2/tree/SPECS2-5.0.7/examples/shared/src/test/scala/examples">examples</a> directory on Github
+      <li>the <a href="https://etorreborre.github.io/specs2/api/SPECS2-5.0.7/index.html">ScalaDoc</a></li>
+      <li>the <a href="https://github.com/etorreborre/specs2/tree/SPECS2-5.0.7/examples/src/test/scala/examples">examples</a> directory on Github
       </li>
       <li>the <a href="https://github.com/etorreborre/specs2/releases">release notes</a>
       </li>


### PR DESCRIPTION
Two of the links at https://etorreborre.github.io/specs2/website/SPECS2-5.0.7/learn.html don't work. This fixes them to point at what I think was intended. Sorry and please let me know if I was wrong.