### PR TITLE
Update AnyMatchers.scala

### DIFF
--- a/matcher/shared/src/main/scala/org/specs2/matcher/AnyMatchers.scala
+++ b/matcher/shared/src/main/scala/org/specs2/matcher/AnyMatchers.scala
@@ -176,7 +176,7 @@ class BeFalseMatcher extends Matcher[Boolean]:
 
 /** Equality Matcher
   */
-class BeEqualTo(t: =>Any) extends EqualityMatcher(t)
+class BeEqualTo[T](t: =>T) extends EqualityMatcher(t)
 
 /** This matcher always matches any value of type T
   */


### PR DESCRIPTION
This fixes a problem where you can't use beEqualTo as a parameter matcher when mocking in mockito.