### PR TITLE
revert #1112

### DIFF
--- a/matcher/shared/src/main/scala/org/specs2/matcher/AnyMatchers.scala
+++ b/matcher/shared/src/main/scala/org/specs2/matcher/AnyMatchers.scala
@@ -176,7 +176,7 @@ class BeFalseMatcher extends Matcher[Boolean]:
 
 /** Equality Matcher
   */
-class BeEqualTo[T](t: =>T) extends EqualityMatcher(t)
+class BeEqualTo(t: =>Any) extends EqualityMatcher(t)
 
 /** This matcher always matches any value of type T
   */

--- a/tests/shared/src/test/scala/org/specs2/matcher/BeEqualToMatcherSpec.scala
+++ b/tests/shared/src/test/scala/org/specs2/matcher/BeEqualToMatcherSpec.scala
@@ -34,6 +34,7 @@ class BeEqualToMatcherSpec extends Spec with ResultMatchers with ShouldMatchers 
   ${"a" must not(be_==("b"))}
   ${"a" must be_!=("b")}
   ${"a" must not(be_!=("a"))}
+  ${object A {override def equals(that: Any) = that == "a"}; A must be_==("a")}
 
   Array equality uses deep array comparison, with or without typed equality
   ${Array(1, 2) must be_==(Array(1, 2))}

--- a/tests/shared/src/test/scala/org/specs2/matcher/BeEqualToMatcherSpec.scala
+++ b/tests/shared/src/test/scala/org/specs2/matcher/BeEqualToMatcherSpec.scala
@@ -5,10 +5,10 @@ import execute.*
 import org.specs2.text.AnsiColors.*
 
 class BeEqualToMatcherSpec extends Spec with ResultMatchers with ShouldMatchers {
-  def is = s2"""
   object A {
     override def equals(that: Any) = that == "a"
   }
+  def is = s2"""
 
   be_== checks the equality of 2 objects
   ${"a" must ===("a")}

--- a/tests/shared/src/test/scala/org/specs2/matcher/BeEqualToMatcherSpec.scala
+++ b/tests/shared/src/test/scala/org/specs2/matcher/BeEqualToMatcherSpec.scala
@@ -34,7 +34,8 @@ class BeEqualToMatcherSpec extends Spec with ResultMatchers with ShouldMatchers 
   ${"a" must not(be_==("b"))}
   ${"a" must be_!=("b")}
   ${"a" must not(be_!=("a"))}
-  ${object A {override def equals(that: Any) = that == "a"}; A must be_==("a")}
+  ${object A {override def equals(that: Any) = that == "a"}
+    A must be_==("a")}
 
   Array equality uses deep array comparison, with or without typed equality
   ${Array(1, 2) must be_==(Array(1, 2))}

--- a/tests/shared/src/test/scala/org/specs2/matcher/BeEqualToMatcherSpec.scala
+++ b/tests/shared/src/test/scala/org/specs2/matcher/BeEqualToMatcherSpec.scala
@@ -37,7 +37,7 @@ class BeEqualToMatcherSpec extends Spec with ResultMatchers with ShouldMatchers 
 
   Distinguish between typed and non typed equality matchers
   ${A must be_==("a")}
-  ${A must not be_===("a")}
+  Will not compile: {A must not be_===("a")}
 
   Array equality uses deep array comparison, with or without typed equality
   ${Array(1, 2) must be_==(Array(1, 2))}

--- a/tests/shared/src/test/scala/org/specs2/matcher/BeEqualToMatcherSpec.scala
+++ b/tests/shared/src/test/scala/org/specs2/matcher/BeEqualToMatcherSpec.scala
@@ -6,6 +6,9 @@ import org.specs2.text.AnsiColors.*
 
 class BeEqualToMatcherSpec extends Spec with ResultMatchers with ShouldMatchers {
   def is = s2"""
+  object A {
+    override def equals(that: Any) = that == "a"
+  }
 
   be_== checks the equality of 2 objects
   ${"a" must ===("a")}
@@ -34,8 +37,7 @@ class BeEqualToMatcherSpec extends Spec with ResultMatchers with ShouldMatchers 
   ${"a" must not(be_==("b"))}
   ${"a" must be_!=("b")}
   ${"a" must not(be_!=("a"))}
-  ${object A {override def equals(that: Any) = that == "a"}
-    A must be_==("a")}
+  ${A must be_==("a")}
 
   Array equality uses deep array comparison, with or without typed equality
   ${Array(1, 2) must be_==(Array(1, 2))}

--- a/tests/shared/src/test/scala/org/specs2/matcher/BeEqualToMatcherSpec.scala
+++ b/tests/shared/src/test/scala/org/specs2/matcher/BeEqualToMatcherSpec.scala
@@ -127,6 +127,6 @@ Details
 
 case class Hello() { override def toString = "hello" }
 
-  object A {
-    override def equals(that: Any) = that == "a"
-  }
+object A {
+  override def equals(that: Any) = that == "a"
+}

--- a/tests/shared/src/test/scala/org/specs2/matcher/BeEqualToMatcherSpec.scala
+++ b/tests/shared/src/test/scala/org/specs2/matcher/BeEqualToMatcherSpec.scala
@@ -5,9 +5,6 @@ import execute.*
 import org.specs2.text.AnsiColors.*
 
 class BeEqualToMatcherSpec extends Spec with ResultMatchers with ShouldMatchers {
-  object A {
-    override def equals(that: Any) = that == "a"
-  }
   def is = s2"""
 
   be_== checks the equality of 2 objects
@@ -37,7 +34,10 @@ class BeEqualToMatcherSpec extends Spec with ResultMatchers with ShouldMatchers 
   ${"a" must not(be_==("b"))}
   ${"a" must be_!=("b")}
   ${"a" must not(be_!=("a"))}
+
+  Distinguish between typed and non typed equality matchers
   ${A must be_==("a")}
+  ${A must not be_===("a")}
 
   Array equality uses deep array comparison, with or without typed equality
   ${Array(1, 2) must be_==(Array(1, 2))}
@@ -126,3 +126,7 @@ Details
 }
 
 case class Hello() { override def toString = "hello" }
+
+  object A {
+    override def equals(that: Any) = that == "a"
+  }


### PR DESCRIPTION
https://github.com/etorreborre/specs2/pull/1112/files This causes beEqualTo usages with vague types to fail compilation.