### PR TITLE
backport JsonMatchers as companion object

### DIFF
--- a/matcher-extra/shared/src/main/scala/org/specs2/matcher/JsonMatchers.scala
+++ b/matcher-extra/shared/src/main/scala/org/specs2/matcher/JsonMatchers.scala
@@ -15,6 +15,8 @@ import Results.negateWhen
  */
 trait JsonMatchers extends JsonBaseMatchers with JsonBaseBeHaveMatchers
 
+object JsonMatchers extends JsonMatchers
+
 private[specs2]
 trait JsonBaseMatchers extends Expectations with JsonMatchersImplicits { outer =>
 


### PR DESCRIPTION
Hi @etorreborre,
we have quite a lot of places using just a few matchers from JsonMatchers.
I thought having them in object form would be a nice addition and saw that it already exists in mainline.
can it be backported? (I hope it's on the right branch...)
Thanks!
(this PR is just for the discussion, feel free to close/edit/whatever...)