### PR TITLE
Update correct line numbers in LocationSpec

### DIFF
--- a/core/jvm/src/test/scala/org/specs2/io/LocationSpec.scala
+++ b/core/jvm/src/test/scala/org/specs2/io/LocationSpec.scala
@@ -15,7 +15,7 @@ class LocationSpec extends org.specs2.mutable.Spec with TypedEqual:
     given spec: LocationUnitSpecification = new LocationUnitSpecification(ee)
 
     "for the first piece of text, with 'should'" >> {
-      textAt(index = 0) === 16
+      textAt(index = 0) === 13
     }
     "for the first example, with 'in'" >> {
       exampleAt(index = 0) === 14
@@ -24,13 +24,13 @@ class LocationSpec extends org.specs2.mutable.Spec with TypedEqual:
       exampleAt(index = 1) === 15
     }
     "for the second piece of text, with '>>'" >> {
-      textAt(index = 1) === 23
+      textAt(index = 1) === 18
     }
     "for the 3rd example, with '>>'" >> {
-      exampleAt(index = 2) === 20
+      exampleAt(index = 2) === 19
     }
     "for the 4th example, with '>>'" >> {
-      exampleAt(index = 3) === 22
+      exampleAt(index = 3) === 21
     }
   }
 


### PR DESCRIPTION
The test breaks with https://github.com/lampepfl/dotty/pull/17428

I'm not sure what the protocol is for a project participating in the community build, where this behavior change was noticed.

Parking this here for reference.

