### PR TITLE
Specify this.run in run

### DIFF
--- a/core/shared/src/main/scala/specs2/run.scala
+++ b/core/shared/src/main/scala/specs2/run.scala
@@ -24,4 +24,4 @@ object run extends ClassRunnerMain:
 
   /** main method for the command line */
   def main(args: Array[String]) =
-    run(args, exit = true)
+    this.run(args, exit = true)


### PR DESCRIPTION
The new comment:

It is an error if an identifier x is available as an inherited member in an inner scope and the same name x is defined in an outer scope in the same source file.

`run` also has an `apply`, so `run()` is doubly potentially confusing.

Just slapping on a disambiguating `this` is harmless and also clarifying.
