### PR TITLE
feat: Add notThrow matcher

### DIFF
--- a/guide/src/test/scala/org/specs2/guide/matchers/ExceptionMatchers.scala
+++ b/guide/src/test/scala/org/specs2/guide/matchers/ExceptionMatchers.scala
@@ -16,11 +16,11 @@ object ExceptionMatchers extends UserGuideCard {
   same message
   * `throwA[ExceptionType].like { case e => e must matchSomething }` or
   `throwA(exception).like { case e => e must matchSomething }` checks that the thrown exception satisfies a property
-  * `throwA[ExceptionType](me.like { case e => e must matchSomething }` or
-  `throwA(exception).like { case e => e must matchSomething }` checks that the thrown exception satisfies a property
 
 ### for expressions that shouldn't throw an exception
-  * `notThrow` checks that an expression doesn't throw any exceptions
+  * `not(throwAn[Exception])` checks that an expression doesn't throw any exceptions
+  * `not(throwAn[Exception].like { case e => e.message must startWith("FAIL") })` checks that an expression doesn't an exception with the specified message (another message is allowed)
+  * `not(throwAn[IllegalArgumentException])` checks that an expression doesn't throw any `IllegalArgumentException` (but exceptions of other types are permitted)
 
 ### for exception values
 

--- a/guide/src/test/scala/org/specs2/guide/matchers/ExceptionMatchers.scala
+++ b/guide/src/test/scala/org/specs2/guide/matchers/ExceptionMatchers.scala
@@ -19,6 +19,9 @@ object ExceptionMatchers extends UserGuideCard {
   * `throwA[ExceptionType](me.like { case e => e must matchSomething }` or
   `throwA(exception).like { case e => e must matchSomething }` checks that the thrown exception satisfies a property
 
+### for expressions that shouldn't throw an exception
+  * `notThrow` checks that an expression doesn't throw any exceptions
+
 ### for exception values
 
   * `beException[ExceptionType]("message")` checks that a `Throwable` has an expected type and that its message satisfies

--- a/matcher/shared/src/main/scala/org/specs2/matcher/ExceptionMatchers.scala
+++ b/matcher/shared/src/main/scala/org/specs2/matcher/ExceptionMatchers.scala
@@ -52,6 +52,10 @@ trait ExceptionMatchers extends ExpectationsCreation:
   def beException[T: ClassTag](message: String): Matcher[Throwable] =
     haveClass[T] and beMatching(message) ^^ ((t: Throwable) => t.getMessage)
 
+  /** A matcher that checks that nothing was thrown.
+    */
+  def notThrow: NotThrowMatcher = new NotThrowMatcher
+
   /** Exception matcher checking the type of a thrown exception.
     */
   class ExceptionClassMatcher(klass: Class[?]) extends Matcher[Any]:
@@ -143,6 +147,16 @@ trait ExceptionMatchers extends ExpectationsCreation:
           checkBoolean(value, checkClassTypeAndMessage, rethrowException).not
 
   end ExceptionMatcher
+
+  class NotThrowMatcher extends Matcher[Any]:
+    outer =>
+
+    def apply[S <: Any](value: Expectable[S]): Result = getException(value.value) match
+      case Some(e) =>
+        Failure(
+          s"Unexpected ${e.getClass} thrown: ${e.getMessage}\n\nThe stacktrace is\n\n${e.getStackTrace.mkString("\n")}"
+        )
+      case None => Success("No exceptions thrown")
 
   private val dropException = (e: Throwable) => ()
 

--- a/tests/shared/src/test/scala/org/specs2/matcher/ExceptionMatchersSpec.scala
+++ b/tests/shared/src/test/scala/org/specs2/matcher/ExceptionMatchersSpec.scala
@@ -75,6 +75,14 @@ class ExceptionMatchersSpec extends Specification with ResultMatchers:
 
  A Throwable can be checked for its class and message $throwable1
 
+ Or not thrown
+ =============
+
+ by using the notThrow matcher: 'value must notThrow'
+  it must succeed if no error is thrown $notThrow1
+  it must fail if any exception is thrown $notThrow2
+  it must include the original stack trace if an exception is thrown $notThrow3
+
 """
 
   type IAE = IllegalArgumentException
@@ -157,3 +165,9 @@ class ExceptionMatchersSpec extends Specification with ResultMatchers:
     (new IllegalArgumentException("incorrect arguments"): Throwable) must beException[IllegalArgumentException](
       ".*arguments.*"
     )
+
+  def notThrow1 = 1 must notThrow
+
+  def notThrow2 = (theBlock(error("boom")) must notThrow) must beFailing
+
+  def notThrow3 = (theBlock(error("boom")) must notThrow).message must contain("The stacktrace is")

--- a/tests/shared/src/test/scala/org/specs2/matcher/ExceptionMatchersSpec.scala
+++ b/tests/shared/src/test/scala/org/specs2/matcher/ExceptionMatchersSpec.scala
@@ -23,27 +23,30 @@ class ExceptionMatchersSpec extends Specification with ResultMatchers:
   it must return an Error when an Exception is expected and a java.lang.Error is thrown $byType6
 
  negated matcher: when we specify not(throw[A])
-  it must return an Error if B is thrown $byType7
-  it must return a Failure if A is thrown $byType8
-  it must return a Success if no exception $byType9
+  it must succeed if no exception is thrown $byType7
+  it must succeed if an exception is thrown with a different type $byType8
+  it must fail if A is thrown $byType9
+  it must fail if a subtype of A is thrown $byType10
+  it must return the exception stacktrace in case of a failure $byType11
 
  With a PartialFunction
  ======================
 
  it is also possible to specify that the thrown exception is ok according to a PartialFunction
-   'error(boom) must throwA[RuntimeException].like(e => e.getMessage(0) === 'b') $pf1
-   'error(boom) must throwA[RuntimeException].like(e => e.getMessage(0) === 'a') will fail $pf2
+   'error(boom) must throwA[RuntimeException].like(e => e.getMessage must startWith("b")) succeeds $pf1
+   'error(boom) must throwA[RuntimeException].like(e => e.getMessage must startWith("a")) fails $pf2
 
  negated matcher: when we specify not(throw[A].like(f))
-  it must return an Error if B is thrown $pf3
-  it must return a Failure if A is thrown like f $pf4
-  it must return an Error if A is thrown not like f $pf5
-  it must return a Success if no exception like f $pf6
+  it must succeed if no exception is thrown $pf3
+  it must succeed if an exception is thrown with a different type $pf4
+  it must succeed if an exception is thrown with with the right type but not satisfying the partial function $pf4
+  it must fail if A is thrown and satisfies the partial function $pf6
+  it must return the exception stacktrace in case of a failure $pf7
 
  With a regular expression
  =========================
 
- more simply the exception message can be specified with a regular expression
+ The exception message can be specified with a regular expression
   'error(boom) must throwA[RuntimeException](message = 'boo') $regex1
   for a multi-line string $regex2
   for match which is followed by multiple lines $regex3
@@ -57,71 +60,97 @@ class ExceptionMatchersSpec extends Specification with ResultMatchers:
   it must fail if an exception of a different class and same message is thrown $specific3
   it must fail if an exception of a same class and different message is thrown $specific4
   it can be refined with a 'like' expression
-   failing if the catched expression doesn't satisfy the partial function $specific5
+   failing if the caught expression doesn't satisfy the partial function $specific5
    succeeding otherwise $specific6
-
- With combinators
- ================
-
-  negating a throw matcher must return the proper success message $combinators1
-
- Stacktrace
- ==========
-
- the stacktrace of the caught exception must be displayed $stacktrace1
 
  An exception value
  ==================
 
  A Throwable can be checked for its class and message $throwable1
 
- Or not thrown
- =============
-
- by using the notThrow matcher: 'value must notThrow'
-  it must succeed if no error is thrown $notThrow1
-  it must fail if any exception is thrown $notThrow2
-  it must include the original stack trace if an exception is thrown $notThrow3
-
 """
 
   type IAE = IllegalArgumentException
 
-  def byType1 = ("hello" must throwAn[Error]).message must ===("Expected: java.lang.Error. Got nothing")
+  def byType1 = ("hello" must throwAn[Error]).message must ===("No exception of type java.lang.Error was thrown")
 
   def byType2 = theBlock(error("boom")) must throwA[RuntimeException]
 
   def byType3 = (theBlock(error("boom")) must throwAn[IAE]).message must startWith(
-    "Expected: java.lang.IllegalArgumentException. Got: java.lang.RuntimeException: boom instead"
+    "Caught an exception of type java.lang.RuntimeException which is not of type java.lang.IllegalArgumentException: boom"
   )
 
   def byType4 = (1 must not(throwA(new Exception))) must beSuccessful
 
   def byType5 = ({ sys.error("boom"); 1 } must not(throwAn[Exception])) must beFailing
 
-  def byType6 = { throw new StackOverflowError("play again"); 1 } must throwAn[Error]
+  def byType6 = ({ throw new StackOverflowError("play again"); 1 } must throwAn[Exception]) must throwA[java.lang.Error]
 
-  def byType7 = AsResult { { throw new NullPointerException; 1 } must not(throwAn[IAE]) } must beError
+  def byType7 = (1 must not(throwAn[Exception])).message must ===("No exception of type java.lang.Exception was thrown")
 
-  def byType8 = AsResult { { throw new IAE; 1 } must not(throwAn[IAE]) } must beFailing
+  def byType8 = {
+    val result = theBlock(error("boom")) must not(throwAn[IllegalArgumentException])
+    result and (result.message must contain(
+      "Caught an exception of type java.lang.RuntimeException which is not of type java.lang.IllegalArgumentException: boom"
+    ))
+  }
 
-  def byType9 = AsResult { 1 must not(throwAn[IAE]) } must beSuccessful
+  def byType9 = (theBlock(error("boom")) must not(throwAn[Exception])) must beFailing
+
+  def byType10 =
+    (theBlock(throw new IllegalArgumentException("boom")) must not(throwA[RuntimeException])) must beFailing
+
+  def byType11 = (theBlock(error("boom")) must not(throwAn[Exception])).message must contain("The stacktrace is")
 
   def pf1 = (theBlock(error("boom")) must throwA[RuntimeException].like { case NonFatal(e) =>
-    e.getMessage()(0) === 'b'
+    e.getMessage must startWith("b")
   })
 
-  def pf2 = (theBlock(error("boom")) must throwA[RuntimeException].like { case NonFatal(e) =>
-    e.getMessage()(0) === 'a'
-  }).message must startWith("Expected: java.lang.RuntimeException. Got: java.lang.RuntimeException: boom and b != a")
+  def pf2 = {
+    val result = theBlock(error("boom")) must throwA[RuntimeException].like { case NonFatal(e) =>
+      e.getMessage must startWith("a")
+    }
+    (result must beFailing) and
+      (result.message must (contain("Caught an exception of type java.lang.RuntimeException: boom")
+        and contain(
+          "the exception does not satisfy the specified condition: boom doesn't start with 'a'"
+        )))
+  }
 
-  def pf3 = AsResult { { throw new NullPointerException; 1 } must not(throwAn[IAE].like { case _ => ok }) } must beError
+  // Partial functions
 
-  def pf4 = AsResult { { throw new IAE; 1 } must not(throwAn[IAE].like { case _ => ok }) } must beFailing
+  def pf3 = (1 must not(throwAn[Exception].like { case _ => ok })).message must ===(
+    "No exception of type java.lang.Exception was thrown"
+  )
 
-  def pf5 = AsResult { { throw new IAE; 1 } must not(throwAn[IAE].like { case _ => ko }) } must beError
+  def pf4 = {
+    val result = theBlock(error("boom")) must not(throwAn[IllegalArgumentException].like { case _ => ok })
+    result and (result.message must contain(
+      "Caught an exception of type java.lang.RuntimeException which is not of type java.lang.IllegalArgumentException: boom"
+    ))
+  }
 
-  def pf6 = AsResult { 1 must not(throwAn[IAE].like { case _ => ok }) } must beSuccessful
+  def pf5 = (1 must not(throwAn[Exception].like { case _ => ko })).message must contain(
+    "Caught an exception of type java.lang.RuntimeException which is not of type java.lang.IllegalArgumentException: boom"
+  )
+
+  def pf6 = {
+    val result = theBlock(error("boom")) must not(throwA[RuntimeException].like { case NonFatal(e) =>
+      e.getMessage must startWith("b")
+    })
+    (result must beFailing) and
+      (result.message must (contain("Caught an exception of type java.lang.RuntimeException: boom")
+        and contain(
+          "The exception satisfies the specified condition: boom doesn't start with 'b'"
+        )))
+  }
+
+  def pf7 = {
+    val result = theBlock(error("boom")) must not(throwA[RuntimeException].like { case NonFatal(e) =>
+      e.getMessage must startWith("b")
+    })
+    result.message must contain("The stacktrace is")
+  }
 
   def regex1 = (theBlock(error("boom")) must throwA[RuntimeException](message = "boo"))
 
@@ -130,44 +159,34 @@ class ExceptionMatchersSpec extends Specification with ResultMatchers:
   def regex3 = (theBlock(error("bang\nboom\nbong")) must throwA[RuntimeException](message = "bang"))
 
   def specific1 = ("hello" must throwA(new RuntimeException("boom"))).message must ===(
-    "Expected: java.lang.RuntimeException: boom. Got nothing"
+    "No exception of type java.lang.RuntimeException was thrown"
   )
 
   def specific2 = (theBlock(error("boom")) must throwAn(new RuntimeException("boom")))
 
   def specific3 = (theBlock(error("boom")) must throwAn(new IAE("boom"))).message must startWith(
-    "Expected: java.lang.IllegalArgumentException: boom. Got: java.lang.RuntimeException: boom instead"
+    "Caught an exception of type java.lang.RuntimeException which is not of type java.lang.IllegalArgumentException: boom"
   )
 
-  def specific4 = (theBlock(error("boom")) must throwAn(new RuntimeException("bang"))).message must startWith(
-    "Expected: java.lang.RuntimeException: bang. Got: java.lang.RuntimeException: boom instead"
-  )
+  def specific4 = {
+    val result = (theBlock(error("boom")) must throwAn(new RuntimeException("bang"))).message
+    (result must startWith("Caught an exception of type java.lang.RuntimeException: boom")) and
+      (result must contain("the exception does not satisfy the specified condition: 'boom' != 'bang'"))
+  }
 
   case class UserError(name: String, message: String) extends RuntimeException(message)
 
   def specific5 = (theBlock(throw UserError("me", "boom")) must throwAn(UserError("me2", "boom")).like {
     case UserError(name, _) => name must endWith("2")
-  }).message must startWith(
-    "Expected: org.specs2.matcher.ExceptionMatchersSpec$UserError: boom. Got: org.specs2.matcher.ExceptionMatchersSpec$UserError: boom and me doesn't end with '2'"
+  }).message must contain(
+    "the exception does not satisfy the specified condition: me doesn't end with '2'"
   )
 
   def specific6 = (theBlock(throw UserError("me", "boom")) must throwAn(UserError("me2", "boom")).like {
     case UserError(name, _) => name must startWith("m")
   })
 
-  def combinators1 = (1 must not(throwAn[Exception])).message must ===("Expected: java.lang.Exception. Got nothing")
-
-  def stacktrace1 = (theBlock(error("boom")) must throwAn[IllegalArgumentException]).message must contain(
-    "The  RuntimeException stacktrace is"
-  )
-
   def throwable1 =
     (new IllegalArgumentException("incorrect arguments"): Throwable) must beException[IllegalArgumentException](
       ".*arguments.*"
     )
-
-  def notThrow1 = 1 must notThrow
-
-  def notThrow2 = (theBlock(error("boom")) must notThrow) must beFailing
-
-  def notThrow3 = (theBlock(error("boom")) must notThrow).message must contain("The stacktrace is")


### PR DESCRIPTION
This is a matcher that checks that no exception is thrown.

It has two advantages over `not(throwA[Throwable])`:

1. It includes the stacktrace of the original exception in the message if it fails.
2. It doesn't require specifying a type.