### PR TITLE
Don’t require a newline after a type mismatch error reported by the compiler

### DIFF
--- a/core/shared/src/test/scala/org/specs2/matcher/TypecheckSpec.scala
+++ b/core/shared/src/test/scala/org/specs2/matcher/TypecheckSpec.scala
@@ -34,8 +34,7 @@ class TypecheckSpec extends Specification:
     result must beFailing(startWith("""|val n: Int = 0;  val s: Int = n + "hello"
                                        |                             ^
                                        |Found:    String
-                                       |Required: Int
-                                       |""".stripMargin))
+                                       |Required: Int""".stripMargin))
 
   def e3 =
     def code1 = """val n: Int = "x";  """
@@ -47,15 +46,13 @@ class TypecheckSpec extends Specification:
     result must beFailing(startWith("""|val n: Int = "x";  val s: Int = "y"
                                        |            ^
                                        |Found:    ("x" : String)
-                                       |Required: Int
-                                       |""".stripMargin))
+                                       |Required: Int""".stripMargin))
 
     result match
       case Failure(_, _, _, FailureDetailsMessages(messages)) =>
         messages(0) must startWith("""|val n: Int = "x";  val s: Int = "y"
                                       |                               ^
                                       |Found:    ("y" : String)
-                                      |Required: Int
-                                      |""".stripMargin)
+                                      |Required: Int""".stripMargin)
       case other =>
         failure(s"unexpected $other")


### PR DESCRIPTION
Currently, the compiler incorrectly reports errors like:

~~~ text
[error]  val n: Int = 0;  val s: Int = n + "hello"
[error]                               ^
[error]  Found:    String
[error]  Required: Int
[error]
[error]  One of the following imports might make progress towards fixing the problem:
[error]
[error]    import org.specs2.io.FileName.ToFileName
[error]    import org.specs2.TimeoutSpecExample.asExecutionIsInterpolated
[error]    import org.specs2.reflect.FromObjectName.asExecutionIsInterpolated
[error]    import org.specs2.reporter.reporterSpecSupport.asExecutionIsInterpolated
[error]    import org.specs2.runner.RunnerSpecification.asExecutionIsInterpolated
[error]    import org.specs2.specification.S1.asExecutionIsInterpolated
[error]    import org.specs2.specification.S2.asExecutionIsInterpolated
[error]    import org.specs2.specification.dsl1.asExecutionIsInterpolated
[error]    import org.specs2.TimeoutSpecExample.asResultIsInterpolated
[error]    import org.specs2.reflect.FromObjectName.asResultIsInterpolated
~~~

But after https://github.com/lampepfl/dotty/pull/17924 is merged, the import suggestions will be removed from the output.

We adjust the test specification in TypecheckSpec to pass both with the current compiler and with the fix in the linked PR.