### PR TITLE
scalacheck: fix reporting wrong initial seed for failure after passing

### DIFF
--- a/scalacheck/src/main/scala/org/specs2/scalacheck/ScalaCheckPropertyCheck.scala
+++ b/scalacheck/src/main/scala/org/specs2/scalacheck/ScalaCheckPropertyCheck.scala
@@ -49,7 +49,7 @@ trait ScalaCheckPropertyCheck extends ExpectationsCreation:
         case _ =>
           val sd = Seed.random()
           (prms0.withInitialSeed(sd), sd)
-      capturedSeed = seed
+      capturedSeed = Option(capturedSeed).getOrElse(seed)
       prop(prms)
     }
 


### PR DESCRIPTION
It seems like seed is rotating between multiple executions of the same property and we override the "initial" one, because:

```scala
import org.scalacheck.rng.Seed
import org.specs2.*
import org.specs2.scalacheck.Parameters

class TestSpec extends Specification with ScalaCheck {

  given Parameters = defaultParameters.copy(
    seed = Seed.fromBase64("cgiY790v4OsAR1_cWqWMGVY-uOIiYEGGnk8piLYlZUP=").toOption
  )

  def is = s2"""$e1 $e2"""

  def e1 = prop { (_: Int) =>
    failure
    /* --- Proper initial seed reported for immediate failure:

    Falsified after 0 passed tests.
    > ARG_0: 0
    > ARG_0_ORIGINAL: -132395243
    The seed is cgiY790v4OsAR1_cWqWMGVY-uOIiYEGGnk8piLYlZUP=
     */
  }

  var isFirst = true
  def e2 = prop { (_: Int) =>
    val result = isFirst === true
    isFirst = false
    result

    /* -- Irrelevant initial seed is reported after at least one run
    Falsified after 1 passed tests.
    > ARG_0: 0
    > ARG_0_ORIGINAL: -2081709915
    The seed is uuB4cK0QVWfLpu2EWB49uF3kXAyjmzUBNksBrxR6hJD=
     */
  }
}

```