### PR TITLE
fix: ordering of given definitions to match new -source:future implicit search rules

### DIFF
--- a/tests/jvm/src/test/scala/org/specs2/specification/core/SpecificationStructureSpec.scala
+++ b/tests/jvm/src/test/scala/org/specs2/specification/core/SpecificationStructureSpec.scala
@@ -78,12 +78,12 @@ class mutabl(val env: Env) extends Specification with ScalaCheck with OwnEnv {
   def dependOn(s2: SpecStructure): Matcher[SpecStructure] = (s1: SpecStructure) =>
     (s1.dependsOn(s2)(ee), s"${s1.specClassName} doesn't depend on ${s2.specClassName}")
 
-  given Arbitrary[SpecificationStructure] =
-    Arbitrary(arbitrary[SpecStructure].map(spec => new SpecificationStructure { def is = spec }))
-
   given Arbitrary[SpecStructure] = Arbitrary {
     (ArbitrarySpecHeader.arbitrary |@| ArbitraryFragments.arbitrary)((sh, fs) => SpecStructure.create(sh, fs))
   }
+
+  given Arbitrary[SpecificationStructure] =
+    Arbitrary(arbitrary[SpecStructure].map(spec => new SpecificationStructure { def is = spec }))
 
   given ArbitraryFragments: Arbitrary[Fragments] =
     Arbitrary(listOf(ArbitraryFragment.arbitrary).map(fs => Fragments.apply(fs*)))
@@ -94,11 +94,11 @@ class mutabl(val env: Env) extends Specification with ScalaCheck with OwnEnv {
   given ArbitraryLinks: Arbitrary[List[Fragment]] =
     Arbitrary(Gen.nonEmptyListOf(ArbitraryLink.arbitrary))
 
-  given ArbitraryLink: Arbitrary[Fragment] =
-    Arbitrary(arbitrary[SpecHeader].map(ss => link(SpecStructure(ss))))
-
   given ArbitrarySpecHeader: Arbitrary[SpecHeader] =
     Arbitrary(Gen.oneOf(Seq(SS1, SS2, SS3, SS4, SS4).map(s => SpecHeader.create(s.getClass))))
+
+  given ArbitraryLink: Arbitrary[Fragment] =
+    Arbitrary(arbitrary[SpecHeader].map(ss => link(SpecStructure(ss))))
 }
 
 object SS1 extends Specification { def is = "" }


### PR DESCRIPTION
We've found a failure in OpenCB for this project, coused by changed implicit seach rules under `-source:future` flag. These requires a specific order or givens defitinition as explain in https://github.com/lampepfl/dotty/pull/19392/files#diff-b961213fc5ea62f83ece999f7275ee195fed5a57e4f1c4e6b39dc9d7232a7a90 
This fix changes order of the givens definitions to allow for compilation in Scala 3.4.x 

[Open CB build logs](https://github.com/VirtusLab/community-build3/actions/runs/7481844264/job/20364544036)