### PR TITLE
Improve scaladocs of `eventually`

### DIFF
--- a/common/shared/src/main/scala/org/specs2/execute/EventuallyResults.scala
+++ b/common/shared/src/main/scala/org/specs2/execute/EventuallyResults.scala
@@ -40,7 +40,7 @@ trait EventuallyResults:
     else retry(0)
 
   /** @return
-    *   a matcher that will retry the nested matcher a given number of times with given duration of sleep in between
+    *   a matcher that will retry the nested matcher a given number of times with a given duration of sleep in between
     */
   def eventually[T: AsResult](retries: Int, sleep: Duration)(result: =>T): T =
     eventually[T](retries, (_: Int) => sleep)(result)

--- a/common/shared/src/main/scala/org/specs2/execute/EventuallyResults.scala
+++ b/common/shared/src/main/scala/org/specs2/execute/EventuallyResults.scala
@@ -40,12 +40,14 @@ trait EventuallyResults:
     else retry(0)
 
   /** @return
-    *   a matcher that will retry the nested matcher a given number of times
+    *   a matcher that will retry the nested matcher a given number of times with given duration of sleep in between
     */
   def eventually[T: AsResult](retries: Int, sleep: Duration)(result: =>T): T =
     eventually[T](retries, (_: Int) => sleep)(result)
 
-  /** @return a result that is retried at least 40 times until it's ok */
+  /** @return
+    *   a matcher that will retry the nested matcher 40 times until it's ok with 100ms sleep in between
+    */
   def eventually[T: AsResult](result: =>T): T =
     eventually(40, (_: Int) => 100.millis)(result)
 


### PR DESCRIPTION
Few improvements/fixes:
- "retried at least 40 times" - that's incorrect, it's retried "up to 40 times", not at least
- did not find what's the default sleep of `eventually()`:
  - matchers guide does not say it: https://etorreborre.github.io/specs2/guide/SPECS2-5.5.8/org.specs2.guide.Matchers.html
  - these scaladocs don't mention it either (https://etorreborre.github.io/specs2/api/SPECS2-5.5.8/org/specs2/execute/EventuallyResults.html#eventually-80a)
  - My IDE (IntelliJ) didn't show code to find the default
- made docs more consistent - it's essentially the same method with default values, but different terms are used, which makes reading docs harder than it has to

So, to understand the default, I went through many steps and ended up having to find the implementation in the GitHub 😅 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved documentation for the `eventually` methods, clarifying their purpose and behavior.
	- Updated comments to specify the retry mechanism and sleep parameters for better user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->