### PR TITLE
scala-parser-combinators v1 for Scala 2.12, v2 for 2.13+

### DIFF
--- a/project/depends.scala
+++ b/project/depends.scala
@@ -41,7 +41,12 @@ object depends {
     ))
 
   def scalaParser = Def.setting {
-    Seq("org.scala-lang.modules" %%% "scala-parser-combinators" % "1.1.2")
+    Seq("org.scala-lang.modules" %%% "scala-parser-combinators" % {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, 12)) => "1.1.2"
+        case _             => "2.4.0"
+      }
+    })
   }
   def scalaParserNative = Def.setting {
     Seq("org.scala-lang.modules" %%% "scala-parser-combinators" % "2.4.0")


### PR DESCRIPTION
Hi @etorreborre!

Currently you depend on scala-parser-combinators v1 for _all_ Scala 2 versions. However, after looking deeper into this, I am pretty sure we just need to stay on v1 for Scala 2.12, but there is no reason to not upgrade scala-parser-combinator to v2 for Scala 2.13+. Because only Scala 2.12 itself uses scala-parser-combinators v1, however Scala 2.13 and 3 do not. I found out during looking at following issue - please see the comment I added there for further explanation:
- https://github.com/playframework/playframework/issues/13179

E.g. also look at other libraries, they do exactly the same meanwhile:
- https://github.com/eed3si9n/scalaxb/blob/v1.12.2/project/dependencies.scala#L69-L72
- https://github.com/sbt/sbt-pgp/blob/v2.3.1/project/Dependencies.scala#L17-L22
- https://github.com/sbt/sbt-native-packager/blob/v1.11.1/build.sbt#L54-L62

Please also see the comment I just added in
- https://github.com/etorreborre/specs2/issues/980#issuecomment-2725932324

I tested locally, with this PR merged I can build Play and run Play applications without version conflicts - of cours we from Play would need a new specs2 version:
- https://github.com/playframework/playframework/pull/13197

@etorreborre I am like 100% sure this is correct. I keep this as draft currently, but would you be able to merge that later and release `SPECS2-4.21.0` with it?