### PR TITLE
Provide an `IsEmpty` instance for `IterableOnce`

### DIFF
--- a/common/shared/src/main/scala/org/specs2/collection/IsEmpty.scala
+++ b/common/shared/src/main/scala/org/specs2/collection/IsEmpty.scala
@@ -14,22 +14,15 @@ object IsEmpty extends IsEmptyLowPriority1:
     def isEmpty: Boolean =
       IsEmpty[T].isEmpty(t)
 
-  given seqIsEmpty[T]: IsEmpty[Seq[T]] with
-    def isEmpty(t: Seq[T]): Boolean =
-      t.isEmpty
-
   given arrayIsEmpty[T]: IsEmpty[Array[T]] with
     def isEmpty(t: Array[T]): Boolean =
       t.isEmpty
 
 trait IsEmptyLowPriority1 extends IsEmptyLowPriority2:
 
-  given listIsEmpty[T]: IsEmpty[List[T]] with
-    def isEmpty(t: List[T]): Boolean =
-      t.isEmpty
-  given optionIsEmpty[T]: IsEmpty[Option[T]] with
-    def isEmpty(t: Option[T]): Boolean =
-      !t.isDefined
+  given iterableOnceIsEmpty: IsEmpty[IterableOnce[?]] with
+    def isEmpty(t: IterableOnce[?]): Boolean =
+      t.iterator.isEmpty
 
   given eitherIsEmpty[E, T]: IsEmpty[Either[E, T]] with
     def isEmpty(t: Either[E, T]): Boolean =


### PR DESCRIPTION
Is it OK to have an `IsEmpty` instance for `IterableOnce`? That way we can avoid some specific instances and also allow `beEmpty` to be used on some additional types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified emptiness checks by consolidating multiple collection-specific implementations into a single, more general approach for all iterable types.
* **Chores**
  * Removed special handling for options and specific collections, streamlining internal logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->