### PR TITLE
Provide the most specific implicit for `IsEmpty` on iterables

### DIFF
--- a/common/shared/src/main/scala/org/specs2/collection/IsEmpty.scala
+++ b/common/shared/src/main/scala/org/specs2/collection/IsEmpty.scala
@@ -38,8 +38,8 @@ trait IsEmptyLowPriority1 extends IsEmptyLowPriority2:
 
 trait IsEmptyLowPriority2:
 
-  given iterableOnceIsEmpty: IsEmpty[IterableOnce[?]] with
-    def isEmpty(t: IterableOnce[?]): Boolean =
+  given iterableOnceIsEmpty[T <: IterableOnce[?]]: IsEmpty[T] with
+    def isEmpty(t: T): Boolean =
       t.iterator.isEmpty
 
   given stringIsEmpty: IsEmpty[String] with

--- a/tests/jvm/src/test/scala/org/specs2/matcher/AnyMatchersSpec.scala
+++ b/tests/jvm/src/test/scala/org/specs2/matcher/AnyMatchersSpec.scala
@@ -46,6 +46,10 @@ class AnyMatchersSpec
   ${Map(1 -> 2) must not(beEmpty)}
   ${Set() must beEmpty}
   ${Set(1) must not(beEmpty)}
+  ${Option.empty[String] must beEmpty[Option[String]]}
+  ${Seq.empty[String] must beEmpty[Seq[String]]}
+  ${Map.empty[String, Int] must beEmpty[Map[String, Int]]}
+  ${Set.empty[String] must beEmpty[Set[String]]}
 
   beLike matches objects against a pattern
   ${List(1, 2) must beLike { case List(a, b) => ok }}


### PR DESCRIPTION
Hi! I want to support this use case:
```scala
futMap must beEmpty.await
```
Since `Matcher` is not covariant, the rhs of must fails right now as `IsEmpty[IterableOnce[?]]` is not a `IsEmpty[Map[K, V]]`. I think this change is okay to fix it. Hoping it does not break binary compatibility.
This is a follow-up to https://github.com/etorreborre/specs2/pull/1345.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test cases to ensure that empty generic containers (such as Option, Seq, Map, and Set) are correctly recognized as empty by the matcher.

* **Refactor**
  * Generalized internal handling of empty checks to support all subtypes of generic collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->