### PR TITLE
Summon a `Matcher[U]` for `U >: T` where `Matcher[T]` is available

### DIFF
--- a/matcher/shared/src/main/scala/org/specs2/matcher/Matcher.scala
+++ b/matcher/shared/src/main/scala/org/specs2/matcher/Matcher.scala
@@ -285,6 +285,8 @@ trait MatcherCreation:
       def f1(t: =>T) = f(t)
       f1
 
+  /** this allows a matcher of a subtype to be used where a matcher of the supertype is expected
+    */
   given widenToSuperMatcher[T: ClassTag, U >: T]: Conversion[Matcher[T], Matcher[U]] with
     def apply(outer: Matcher[T]): Matcher[U] =
       new Matcher[U]:

--- a/tests/jvm/src/test/scala/org/specs2/matcher/MatcherSpec.scala
+++ b/tests/jvm/src/test/scala/org/specs2/matcher/MatcherSpec.scala
@@ -112,8 +112,8 @@ Messages
     case class Bar1(i: Int) extends Bar
     case class Bar2(s: String) extends Bar
     val beOk: Matcher[Bar] = beEqualTo(Bar2("ok")).when(true)
-    (Bar2("ok"): Bar) must beOk
-    ((Bar1(0): Bar) must beOk).message === "Bar1(0) is not a Bar2"
+    ((Bar2("ok"): Bar) must beOk) and ((Bar2("nok"): Bar) must not(beOk)) and
+      (((Bar1(0): Bar) must beOk).message === "Bar1(0) is not a Bar2")
 
   def collection1 =
     def beEven: Matcher[Int] = (i: Int) => (i % 2 == 0, i.toString + " is odd")

--- a/tests/jvm/src/test/scala/org/specs2/matcher/MatcherSpec.scala
+++ b/tests/jvm/src/test/scala/org/specs2/matcher/MatcherSpec.scala
@@ -29,6 +29,7 @@ Implicit conversions
 
   a matcher can be defined by a function with 1 message $convert1
   a matcher can be muted and will output no message $convert2
+  a matcher can be widen $convert3
 
 Collections
 ===========
@@ -105,6 +106,14 @@ Messages
 
   def convert2 =
     (1 must be_==(1).mute) returns ""
+
+  def convert3 =
+    sealed trait Bar
+    case class Bar1(i: Int) extends Bar
+    case class Bar2(s: String) extends Bar
+    val bar2Matcher: Matcher[Bar2] = beEqualTo(Bar2("ok"))
+    (Bar2("ok"): Bar) must bar2Matcher
+    (Bar1(0): Bar) must not(bar2Matcher)
 
   def collection1 =
     def beEven: Matcher[Int] = (i: Int) => (i % 2 == 0, i.toString + " is odd")

--- a/tests/jvm/src/test/scala/org/specs2/matcher/MatcherSpec.scala
+++ b/tests/jvm/src/test/scala/org/specs2/matcher/MatcherSpec.scala
@@ -111,9 +111,9 @@ Messages
     sealed trait Bar
     case class Bar1(i: Int) extends Bar
     case class Bar2(s: String) extends Bar
-    val bar2Matcher: Matcher[Bar2] = beEqualTo(Bar2("ok"))
-    (Bar2("ok"): Bar) must bar2Matcher
-    (Bar1(0): Bar) must not(bar2Matcher)
+    val beOk: Matcher[Bar] = beEqualTo(Bar2("ok")).when(true)
+    (Bar2("ok"): Bar) must beOk
+    ((Bar1(0): Bar) must beOk).message === "Bar1(0) is not a Bar2"
 
   def collection1 =
     def beEven: Matcher[Int] = (i: Int) => (i % 2 == 0, i.toString + " is odd")


### PR DESCRIPTION
Fixes https://github.com/etorreborre/specs2/issues/1356.
This makes sense to me, but it does mean that something like
```scala
Unrelated1(...) must beEqualTo(Unrelated2(...)).someMethod
```
will now compile and only fail at runtime. This does not seem that bad, since
```scala
Unrelated1(...) must beEqualTo(Unrelated2(...))
```
already compiles as of now.
I've tried to set some constraint against `Any` and/or `AnyRef`, but then the implicit conversion stopped being considered. Please let me know if this can be improved!