### PR TITLE
Migrate the build to sbt 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}; githubWorkflowCheck'
 
       - name: Build and test 🔧
-        run: sbt '++ ${{ matrix.scala }}; testOnly -- xonly exclude ci,website timefactor 3'
+        run: sbt '++ ${{ matrix.scala }}; testOnly * -- xonly exclude ci,website timefactor 3'
 
   publish:
     name: Publish Artifacts
@@ -98,11 +98,11 @@ jobs:
       
       - name: Release to Sonatype 📇
         env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           PGP_KEY_ID: ${{ secrets.PGP_KEY_ID }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
         run: |
           sbt ci-release 2>&1 | tee /tmp/sonatype-output.txt
           EXIT_CODE=${PIPESTATUS[0]}
@@ -158,4 +158,4 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev libstdc++-12-dev
 
       - name: Test Scala Native 🔧
-        run: sbt 'fpNative/test; commonNative/test; matcherNative/test; coreNative/test; matcherExtraNative/test; scalacheckNative/test; xmlNative/test'
+        run: sbt 'fpNative/testFull; commonNative/testFull; matcherNative/testFull; coreNative/testFull; matcherExtraNative/testFull; scalacheckNative/testFull; xmlNative/testFull'

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import com.typesafe.tools.mima.core._
+import sbt.protocol.testing.TestResult
 
 /** ROOT PROJECT */
 
@@ -66,8 +67,9 @@ lazy val rootSettings =
     releaseSettings ++
     Seq(
       Compile / doc / sources := sources.all(aggregateCompile).value.flatten,
-      packagedArtifacts := Map.empty,
-      test := {},
+      packagedArtifacts := Def.uncached(Map.empty),
+      // the root project only aggregates the modules, it has no tests of its own
+      test := TestResult.Passed,
       mimaPreviousArtifacts := Set(),
       mimaFailOnNoPrevious := false
     )
@@ -486,7 +488,7 @@ lazy val testJsSettings = Seq(
 
 /** RELEASE
   */
-lazy val releaseSettings: Seq[Setting[_]] = Seq(
+lazy val releaseSettings: Seq[Setting[?]] = Seq(
   ThisBuild / versionScheme := Some("early-semver"),
   ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("21")),
   ThisBuild / githubWorkflowArtifactUpload := false,
@@ -495,7 +497,7 @@ lazy val releaseSettings: Seq[Setting[_]] = Seq(
   ),
   ThisBuild / githubWorkflowBuild := Seq(
     WorkflowStep
-      .Sbt(name = Some("Build and test 🔧"), commands = List("testOnly -- xonly exclude ci,website timefactor 3"))
+      .Sbt(name = Some("Build and test 🔧"), commands = List("testOnly * -- xonly exclude ci,website timefactor 3"))
   ),
   ThisBuild / githubWorkflowAddedJobs ++= Seq(
     WorkflowJob(
@@ -514,13 +516,13 @@ lazy val releaseSettings: Seq[Setting[_]] = Seq(
           WorkflowStep.Sbt(
             name = Some("Test Scala Native 🔧"),
             commands = List(
-              "fpNative/test",
-              "commonNative/test",
-              "matcherNative/test",
-              "coreNative/test",
-              "matcherExtraNative/test",
-              "scalacheckNative/test",
-              "xmlNative/test"
+              "fpNative/testFull",
+              "commonNative/testFull",
+              "matcherNative/testFull",
+              "coreNative/testFull",
+              "matcherExtraNative/testFull",
+              "scalacheckNative/testFull",
+              "xmlNative/testFull"
             )
           )
         )
@@ -569,8 +571,8 @@ lazy val releaseSettings: Seq[Setting[_]] = Seq(
   ),
   ThisBuild / git.useGitDescribe := true,
   ThisBuild / dynverTagPrefix := SPECS2,
-  ThisBuild / git.gitTagToVersionNumber := { tag: String =>
-    if (tag matches SPECS2 + ".*") Some(tag.replace(SPECS2, "")) else None
+  ThisBuild / git.gitTagToVersionNumber := { (tag: String) =>
+    if (tag.matches(SPECS2 + ".*")) Some(tag.replace(SPECS2, "")) else None
   },
   ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(
     fp.js,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.13.0
+sbt.version=2.0.7

--- a/project/depends.scala
+++ b/project/depends.scala
@@ -1,8 +1,6 @@
 import sbt._
 import Keys._
 import Defaults._
-// necessary for the %%% syntax
-import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 // necessary for accessing the scalaJSVersion property
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 // necessary for accessing the nativeVersion property
@@ -14,14 +12,14 @@ object depends {
   val sbt = libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0"
 
   // used in specs2-scalacheck
-  val scalacheck = libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.19.0"
-  val scalacheckTest = libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.19.0" % Test
+  val scalacheck = libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.19.0"
+  val scalacheckTest = libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.19.0" % Test
 
   // used in specs2-matcher-extra
-  val scalaParser = libraryDependencies += "org.scala-lang.modules" %%% "scala-parser-combinators" % "2.4.0"
+  val scalaParser = libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "2.4.0"
 
   // used in specs2-xml, and transitively by specs2-junit, specs2-matcher-extra, specs2-markdown
-  val scalaXml = libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % "2.4.0"
+  val scalaXml = libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "2.4.0"
 
   // used in specs2-junit
   val junitVersion = "6.1.3"
@@ -49,28 +47,31 @@ object depends {
   def jvmTest =
     Seq(
       libraryDependencies ++= Seq(
-        ("org.portable-scala" %%% "portable-scala-reflect" % "1.1.3").cross(CrossVersion.for3Use2_13),
+        ("org.portable-scala" %% "portable-scala-reflect" % "1.1.3").cross(CrossVersion.for3Use2_13),
         "org.scala-sbt" % "test-interface" % "1.0"
       )
     )
 
   def jsMacrotaskExecutor =
-    Seq(libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.1")
+    Seq(libraryDependencies += "org.scala-js" %% "scala-js-macrotask-executor" % "1.1.1")
 
   def jsTest =
     Seq(
       libraryDependencies ++=
         Seq(
-          ("org.portable-scala" %%% "portable-scala-reflect" % "1.1.3").cross(CrossVersion.for3Use2_13),
-          ("org.scala-js" %% "scalajs-test-interface" % scalaJSVersion).cross(CrossVersion.for3Use2_13)
+          ("org.portable-scala" %% "portable-scala-reflect" % "1.1.3").cross(CrossVersion.for3Use2_13),
+          // scalajs-test-interface is published without a platform suffix
+          ("org.scala-js" %% "scalajs-test-interface" % scalaJSVersion)
+            .cross(CrossVersion.for3Use2_13)
+            .withPlatformOpt(Some("jvm"))
         )
     )
 
   def nativeTest =
     Seq(
       libraryDependencies ++= Seq(
-        "org.scala-native" %%% "test-interface" % nativeVersion,
-        ("org.portable-scala" %%% "portable-scala-reflect" % "1.1.3").cross(CrossVersion.for3Use2_13)
+        "org.scala-native" %% "test-interface" % nativeVersion,
+        ("org.portable-scala" %% "portable-scala-reflect" % "1.1.3").cross(CrossVersion.for3Use2_13)
       )
     )
 }


### PR DESCRIPTION
Supersedes #1622. Scala Steward's bare `sbt.version=2.0.7` bump cannot work on its own: sbt 2 changes enough of the build API that the definition has to be migrated with it.

## What sbt 2 required

**`%%%` no longer exists.** `sbt-platform-deps` only ever existed to provide `%%%`, and it is deliberately not published for sbt 2 — `%%` is platform-aware there, as the [sbt-crossproject README](https://github.com/portable-scala/sbt-crossproject#readme) now states. So the import is gone and the nine `%%%` in `project/depends.scala` are `%%`.

One wrinkle: sbt 2 applies the platform suffix (`_sjs1`, `_native0.5`) from the project's platform axis, *independently* of `crossVersion`, so `.cross(CrossVersion.for3Use2_13)` no longer strips it. `scalajs-test-interface` is published with no platform suffix at all, so it opts out with `.withPlatformOpt(Some("jvm"))`.

A side effect, and an improvement: `portable-scala-reflect` now resolves as `_sjs1_2.13` / `_native0.5_2.13` in the JS and Native builds instead of the JVM jar.

**`test` is now incremental and returns a `TestResult`.** `X/test` delegates to `testQuick`, so it can silently run nothing. Both CI jobs are now explicit about wanting a full run:

- Build and test: `testOnly *` (keeps the specs2 args, which a `TaskKey` like `testFull` cannot take)
- Test Scala Native: `testFull`

Without this the suite reported `No tests to run` for all 17 projects and exited **0**.

**Task results must be serialisable to be cached**, hence `Def.uncached` for the root's `packagedArtifacts`.

**`.sbt` files compile with Scala 3**, so `Seq[Setting[_]]` → `Seq[Setting[?]]`, `{ tag: String => … }` → `{ (tag: String) => … }`, and `tag matches x` → `tag.matches(x)`.

## Verification

Run locally on JDK 21 against this branch. Test counts are identical to the last green sbt 1 run on `main` ([run 32500007422](https://github.com/etorreborre/specs2/actions/runs/32500007422)):

| Suite | Counts | Result |
|---|---|---|
| JVM + JS (`testOnly *`) | 925, 717, 632, 384, 383, 103, 33, 29, 28, 22×3, 20, 17, 10 | 0 failed, 0 errors |
| Native (`testFull`) | 383, 22 | 0 failed, 0 errors |

`githubWorkflowCheck`, `scalafmtCheckAll` and `mimaReportBinaryIssues` all pass.

## Notes

- sbt 2 needs JDK 17+. `main` already builds on temurin@21 and @25, so no matrix change here. The same bump on `specs2-cross` and `specs2-4.x-maintenance` (#1624, #1623) does need one — both pin temurin@11.
- The regenerated `ci.yml` reorders the env vars in the Sonatype step. That is just `Map` iteration under Scala 3; it has to be committed or `githubWorkflowCheck` fails.
- `guide/…/Installation.scala` still tells Scala.js users to write `%%%`. Correct for anyone on sbt 1, stale for sbt 2 — left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test execution reliability across JVM, Scala.js, and Scala Native builds.
  * Ensured all configured tests run during continuous integration and release validation.

* **Chores**
  * Updated the build tooling to a newer SBT version.
  * Refined cross-platform dependency handling to improve build compatibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->