### PR TITLE
Migrate the specs2-cross build to sbt 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [3.3.8]
-        java: [temurin@11]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -31,12 +31,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: sbt
 
       - name: Setup sbt
@@ -46,7 +46,7 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}; githubWorkflowCheck'
 
       - name: Build project
-        run: sbt '++ ${{ matrix.scala }}; testOnly -- xonly exclude ci'
+        run: sbt '++ ${{ matrix.scala }}; testOnly * -- xonly exclude ci'
 
   publish:
     name: Publish Artifacts
@@ -56,7 +56,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [3.3.8]
-        java: [temurin@11]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -64,12 +64,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: sbt
 
       - name: Setup sbt

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import sbt._
+import sbt.protocol.testing.TestResult
 import Defaults._
 import java.util.{Date, TimeZone}
 import java.text.SimpleDateFormat
@@ -13,15 +14,16 @@ lazy val specs2 = project.in(file(".")).
     siteSettings,
     apiSettings,
     name := "specs2",
-    packagedArtifacts := Map.empty,
+    packagedArtifacts := Def.uncached(Map.empty),
     ThisBuild / githubWorkflowArtifactUpload := false,
     ThisBuild / githubWorkflowUseSbtThinClient := false,
-    ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11")),
-    ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("testOnly -- xonly exclude ci"), name = Some("Build project"))),
+    ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17")),
+    ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("testOnly * -- xonly exclude ci"), name = Some("Build project"))),
     // scalacheck 1.19.0 was built against scala-native 0.5.8; allow eviction to 0.5.12
     ThisBuild / libraryDependencySchemes += "org.scala-native" % "test-interface_native0.5_3" % "always",
     Global / onChangedBuildSource := ReloadOnSourceChanges,
-    test := {}
+    // the root project only aggregates the modules, it has no tests of its own
+    test := TestResult.Passed
   ).aggregate(
     fpJVM, catsJVM, commonJVM, matcherJVM, coreJVM, matcherExtraJVM, scalazJVM, html,
     formJVM, markdownJVM, junitJVM, scalacheckJVM, xmlJVM,
@@ -54,8 +56,7 @@ lazy val scalazVersion = settingKey[String]("defines the current scalaz version"
 lazy val catsVersion = "2.13.0"
 lazy val catsEffectVersion = "3.7.0"
 
-val commonSettings: Seq[Def.Setting[_]] =
-    coreDefaultSettings  ++
+val commonSettings: Seq[Def.Setting[?]] =
     specs2Settings       ++
     compilationSettings  ++
     testingSettings
@@ -67,9 +68,12 @@ def commonJvmSettings =
 lazy val cats = crossProject(JSPlatform, JVMPlatform).in(file("cats")).
   settings(
     commonSettings,
+    // the JVM artifacts are used on every platform, as they were with sbt 1:
+    // the JS and Native builds of cats-effect do not expose unsafeRunSync,
+    // which IOMatchers needs
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats-core" % catsVersion,
-      "org.typelevel" %% "cats-effect" % catsEffectVersion
+      ("org.typelevel" %% "cats-core" % catsVersion).withPlatformOpt(Some("jvm")),
+      ("org.typelevel" %% "cats-effect" % catsEffectVersion).withPlatformOpt(Some("jvm"))
     ),
     name := "specs2-cats"
   ).
@@ -295,7 +299,7 @@ lazy val specs2ShellPrompt = ThisBuild / shellPrompt := { state =>
 def scalaSourceVersion(scalaBinaryVersion: String) =
   scalaBinaryVersion.split('.').take(2).mkString(".")
 
-lazy val compilationSettings: Seq[Def.Setting[_]] = Seq(
+lazy val compilationSettings: Seq[Def.Setting[?]] = Seq(
   // https://gist.github.com/djspiewak/976cd8ac65e20e136f05
   Compile / unmanagedSourceDirectories ++=
     Seq((Compile / sourceDirectory).value / s"scala-${scalaSourceVersion(scalaBinaryVersion.value)}",
@@ -379,9 +383,13 @@ lazy val siteSettings = GhpagesPlugin.projectSettings ++ SitePlugin.projectSetti
     makeSite / includeFilter := AllPassFilter,
     // override the synchLocal task to avoid removing the existing files
     ghpagesSynchLocal := {
-      val betterMappings = ghpagesPrivateMappings.value map { case (file, target) => (file, ghpagesUpdatedRepository.value / target) }
+      val converter = fileConverter.value
+      val repository = ghpagesUpdatedRepository.value
+      val betterMappings = ghpagesPrivateMappings.value.map { case (file, target) =>
+        (converter.toPath(file).toFile, repository / target)
+      }
       IO.copy(betterMappings)
-      ghpagesUpdatedRepository.value
+      repository
     },
     git.remoteRepo := "git@github.com:etorreborre/specs2.git"
   )
@@ -425,7 +433,7 @@ ThisBuild / developers := List(
 
 ThisBuild / description := "software specifications for Scala"
 ThisBuild / licenses := List(
-  "MIT" -> java.net.URI.create("https://opensource.org/license/mit").toURL()
+  License("MIT", java.net.URI.create("https://opensource.org/license/mit"))
 )
 ThisBuild / homepage := Some(url("https://github.com/etorreborre/specs2"))
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.13.0
+sbt.version=2.0.7

--- a/project/depends.scala
+++ b/project/depends.scala
@@ -1,6 +1,5 @@
 import sbt._
 import Keys._
-import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport._
 
@@ -16,18 +15,20 @@ object depends {
     Seq("org.scalaz" %% "scalaz-core",
         "org.scalaz" %% "scalaz-effect").map(_ % scalazVersion)
 
+  // scalaz-concurrent is only published for the JVM, so the JS and Native
+  // projects keep using the JVM artifact as they did with sbt 1
   def scalazConcurrent(scalazVersion: String) =
-    "org.scalaz" %% "scalaz-concurrent" % scalazVersion
+    ("org.scalaz" %% "scalaz-concurrent" % scalazVersion).withPlatformOpt(Some("jvm"))
 
-  def jvmTest: Seq[Def.Setting[_]] =
+  def jvmTest: Seq[Def.Setting[?]] =
     Seq(libraryDependencies ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
          case Some((3, _)) =>
            Seq(
-             ("org.portable-scala" %%% "portable-scala-reflect" % "1.1.3").cross(CrossVersion.for3Use2_13),
+             ("org.portable-scala" %% "portable-scala-reflect" % "1.1.3").cross(CrossVersion.for3Use2_13),
              "org.scala-sbt" % "test-interface" % "1.0")
          case _ =>
-           Seq(("org.portable-scala" %%% "portable-scala-reflect" % "1.1.3").cross(CrossVersion.for3Use2_13),
+           Seq(("org.portable-scala" %% "portable-scala-reflect" % "1.1.3").cross(CrossVersion.for3Use2_13),
                 "org.scala-sbt" % "test-interface" % "1.0",
                 "org.scala-js" %% "scalajs-stubs" % "1.0.0" % "provided")
       }
@@ -35,27 +36,30 @@ object depends {
 
   def jsTest =
     Seq(
-      jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv(),
+      jsEnv := Def.uncached(new org.scalajs.jsenv.nodejs.NodeJSEnv()),
       libraryDependencies ++=
         Seq(
-          ("org.portable-scala" %%% "portable-scala-reflect" % "1.1.3").cross(CrossVersion.for3Use2_13),
-          ("org.scala-js" %% "scalajs-test-interface" % scalaJSVersion).cross(CrossVersion.for3Use2_13)
+          ("org.portable-scala" %% "portable-scala-reflect" % "1.1.3").cross(CrossVersion.for3Use2_13),
+          // scalajs-test-interface is published without a platform suffix
+          ("org.scala-js" %% "scalajs-test-interface" % scalaJSVersion)
+            .cross(CrossVersion.for3Use2_13)
+            .withPlatformOpt(Some("jvm"))
         )
     )
 
   def jsMacrotaskExecutor =
-    Seq(libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.1")
+    Seq(libraryDependencies += "org.scala-js" %% "scala-js-macrotask-executor" % "1.1.1")
 
   def nativeTest =
     Seq(libraryDependencies ++= Seq(
-    "org.scala-native" %%% "test-interface" % nativeVersion,
-    ("org.portable-scala" %%% "portable-scala-reflect" % "1.1.3").cross(CrossVersion.for3Use2_13)
+    "org.scala-native" %% "test-interface" % nativeVersion,
+    ("org.portable-scala" %% "portable-scala-reflect" % "1.1.3").cross(CrossVersion.for3Use2_13)
     ))
 
   // used in specs2-matcher-extra
-  def scalaParser = libraryDependencies += "org.scala-lang.modules" %%% "scala-parser-combinators" % "2.4.0"
+  def scalaParser = libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "2.4.0"
 
-  def scalaXml = libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % "2.4.0"
+  def scalaXml = libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "2.4.0"
 
   lazy val mockito  = "org.mockito"  % "mockito-core"  % "5.19.0"
   lazy val junit    = "junit"        % "junit"         % "4.13.2"
@@ -66,7 +70,7 @@ object depends {
   lazy val tagsoup = "org.ccil.cowan.tagsoup" % "tagsoup" % "1.2.1"
 
   lazy val scalacheck = Def.setting {
-    "org.scalacheck" %%% "scalacheck" % "1.19.0"
+    "org.scalacheck" %% "scalacheck" % "1.19.0"
   }
 
 


### PR DESCRIPTION
Supersedes #1624. Scala Steward's bare `sbt.version=2.0.7` bump cannot work on its own: sbt 2 changes enough of the build API that the definition has to be migrated with it, and it requires JDK 17.

## What sbt 2 required

**`%%%` no longer exists.** `sbt-platform-deps` only ever existed to provide `%%%`, and it is deliberately not published for sbt 2 — `%%` is platform-aware there, as the [sbt-crossproject README](https://github.com/portable-scala/sbt-crossproject#readme) now states.

**`coreDefaultSettings` had to go.** `commonSettings` started with `coreDefaultSettings ++ …`, which every project already has. Harmless duplication on sbt 1; on sbt 2 it re-applies the old path layout and puts build outputs outside `target/out`, which produced **105** `Cannot cache task because its output files are outside the output directory` errors. Removing the line fixes all of them and outputs land in `target/out/…` as sbt 2 expects.

**`test` is now incremental and returns a `TestResult`.** `X/test` delegates to `testQuick`, so it can silently run nothing — the workflow now runs `testOnly *`, which is an explicit selection and still accepts the specs2 args.

**Task results must be serialisable to be cached**, hence `Def.uncached` for `packagedArtifacts` and for the Node.js `jsEnv`.

**Two type changes:** `licenses` holds `License` values rather than `(String, URL)` pairs (and takes a `URI`), and `ghpagesPrivateMappings` yields `HashedVirtualFileRef`s, which need `fileConverter` before `IO.copy` can take them.

## Dependencies pinned to their JVM artifacts

sbt 2 applies the platform suffix from the project's platform axis independently of `crossVersion`, so `%%` now asks for the platform variant where sbt 1 silently used the JVM one. Two dependencies are pinned with `withPlatformOpt(Some("jvm"))` to keep resolution exactly as it was:

- **`scalaz-concurrent`** — only ever published for the JVM, no `_sjs1` or `_native0.5` artifact exists.
- **`cats-core` / `cats-effect`** — these *do* publish JS and Native artifacts, and picking them up makes `cats/shared/…/IOMatchers.scala` fail to compile, because `unsafeRunSync` does not exist on Scala.js.

That second one means `specs2-cats_sjs1_3` has been built against the JVM cats-effect all along. **This PR preserves that rather than fixing it** — the real fix is making `IOMatchers` JVM-only, which changes a published module's API and deserves its own change.

## Verification

Run locally on JDK 21. Test counts are identical to the last green sbt 1 run on this branch ([job 96827670958](https://github.com/etorreborre/specs2/actions/runs/32500140253)):

| | Counts |
|---|---|
| sbt 1 (temurin@11) | 1, 10, 14, 17, 22×3, 26, 29, 56, 102, 324×2, 677, 907 |
| sbt 2 (this branch) | **identical** |

0 failed, 0 errors on both. `githubWorkflowCheck` passes and the JVM, JS and Native modules all compile.

## Notes

- **JDK 11 coverage is lost.** sbt 2 refuses to start below JDK 17, so there is no configuration that keeps both. The matrix moves to temurin@17. This branch's publish job is gated on `refs/heads/main`, so released artifacts are not affected by CI.
- This branch compiles with `-old-syntax -rewrite`, so scalac patches sources in place on every build. That is unrelated to this change, but it means a local compile leaves modified source files behind; they are deliberately not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
