### PR TITLE
Migrate the specs2-4.x-maintenance build to sbt 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.18, 2.12.21]
-        java: [temurin@11]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -31,12 +31,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: sbt
 
       - name: Setup sbt
@@ -46,7 +46,7 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}; githubWorkflowCheck'
 
       - name: Build project
-        run: sbt '++ ${{ matrix.scala }}; testOnly -- xonly exclude ci'
+        run: sbt '++ ${{ matrix.scala }}; testOnly * -- xonly exclude ci'
 
   publish:
     name: Publish Artifacts
@@ -56,7 +56,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.18]
-        java: [temurin@11]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -64,12 +64,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: sbt
 
       - name: Setup sbt

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import sbt._
+import sbt.protocol.testing.TestResult
 import Defaults._
 // shadow sbt-scalajs' crossProject and CrossType until Scala.js 1.0.0 is released
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
@@ -11,16 +12,17 @@ lazy val specs2 = project.in(file(".")).
     siteSettings,
     apiSettings,
     name := "specs2",
-    packagedArtifacts := Map.empty,
+    packagedArtifacts := Def.uncached(Map.empty),
     ThisBuild / githubWorkflowArtifactUpload := false,
     ThisBuild / githubWorkflowUseSbtThinClient := false,
-    ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11")),
-    ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("testOnly -- xonly exclude ci"), name = Some("Build project"))),
+    ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17")),
+    ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("testOnly * -- xonly exclude ci"), name = Some("Build project"))),
     // scalacheck 1.19.0 was built against scala-native 0.5.8; allow eviction to 0.5.12
     ThisBuild / libraryDependencySchemes += "org.scala-native" % "test-interface_native0.5_2.13" % "always",
     ThisBuild / libraryDependencySchemes += "org.scala-native" % "test-interface_native0.5_2.12" % "always",
     Global / onChangedBuildSource := ReloadOnSourceChanges,
-    test := {}
+    // the root project only aggregates the modules, it has no tests of its own
+    test := TestResult.Passed
   ).aggregate(
     fpJVM, catsJVM, commonJVM, matcherJVM, coreJVM, matcherExtraJVM, scalazJVM, html,
     analysisJVM, shapelessJVM, formJVM, markdownJVM, gwtJVM, junitJVM, scalacheckJVM, mockJVM, xmlJVM,
@@ -36,7 +38,8 @@ lazy val specs2Settings = Seq(
   GlobalScope / scalazVersion := "7.2.36",
   specs2ShellPrompt,
   ThisBuild / scalaVersion := "2.13.18",
-  SettingKey[Boolean]("ide-skip-project").withRank(KeyRanks.Invisible) := platformDepsCrossVersion.value == ScalaNativeCrossVersion.binary,
+  // the IDE does not need the Scala Native projects
+  SettingKey[Boolean]("ide-skip-project").withRank(KeyRanks.Invisible) := platform.value.startsWith("native"),
   ThisBuild / crossScalaVersions := Seq("2.13.18", "2.12.21"))
 
 lazy val tagName = Def.setting {
@@ -71,7 +74,6 @@ lazy val catsVersion = "2.13.0"
 lazy val catsEffectVersion = "3.7.0"
 
 val commonSettings =
-    coreDefaultSettings  ++
     specs2Settings       ++
     compilationSettings  ++
     testingSettings
@@ -99,9 +101,10 @@ lazy val analysisNative = analysis.native
 lazy val cats = crossProject(JSPlatform, JVMPlatform, NativePlatform).in(file("cats")).
   settings(
     commonSettings,
+    // the JVM artifacts are used on every platform, as they were with sbt 1
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats-core" % catsVersion,
-      "org.typelevel" %% "cats-effect" % catsEffectVersion
+      ("org.typelevel" %% "cats-core" % catsVersion).withPlatformOpt(Some("jvm")),
+      ("org.typelevel" %% "cats-effect" % catsEffectVersion).withPlatformOpt(Some("jvm"))
     ),
     name := "specs2-cats"
   ).
@@ -215,7 +218,7 @@ lazy val gwt = crossProject(JSPlatform, JVMPlatform, NativePlatform).
   in(file("gwt")).
   settings(
     commonSettings,
-    libraryDependencies += "com.chuusai" %%% "shapeless" % shapelessVersion,
+    libraryDependencies += "com.chuusai" %% "shapeless" % shapelessVersion,
     name := "specs2-gwt").
   jvmSettings(depends.jvmTest, commonJvmSettings).
   jsSettings(depends.jsTest, commonJsSettings).
@@ -305,7 +308,7 @@ lazy val shapeless = crossProject(JSPlatform, JVMPlatform, NativePlatform).
   settings(
     commonSettings,
     name := "specs2-shapeless",
-    libraryDependencies += "com.chuusai" %%% "shapeless" % shapelessVersion
+    libraryDependencies += "com.chuusai" %% "shapeless" % shapelessVersion
   ).
   jsSettings(depends.jsTest, commonJsSettings).
   jvmSettings(depends.jvmTest, commonJvmSettings).
@@ -467,7 +470,8 @@ lazy val testingSettings = Seq(
 )
 
 lazy val testingJvmSettings = Seq(
-  javaOptions ++= Seq("-Xmx3G", "-Xss4M"),
+  // pegdown/parboiled reflects into ClassLoader internals, which JDK 17 encapsulates
+  javaOptions ++= Seq("-Xmx3G", "-Xss4M", "--add-opens", "java.base/java.lang=ALL-UNNAMED"),
   Test / fork := true
 )
 
@@ -482,7 +486,10 @@ lazy val siteSettings = GhpagesPlugin.projectSettings ++ SitePlugin.projectSetti
     makeSite / includeFilter := AllPassFilter,
     // override the synchLocal task to avoid removing the existing files
     ghpagesSynchLocal := {
-      val betterMappings = ghpagesPrivateMappings.value map { case (file, target) => (file, ghpagesUpdatedRepository.value / target) }
+      val converter = fileConverter.value
+      val betterMappings = ghpagesPrivateMappings.value.map { case (file, target) =>
+        (converter.toPath(file).toFile, ghpagesUpdatedRepository.value / target)
+      }
       IO.copy(betterMappings)
       ghpagesUpdatedRepository.value
     },
@@ -535,7 +542,7 @@ ThisBuild / developers := List(
 
 ThisBuild / description := "software specifications for Scala"
 ThisBuild / licenses := List(
-  "MIT" -> java.net.URI.create("https://opensource.org/license/mit").toURL()
+  License("MIT", java.net.URI.create("https://opensource.org/license/mit"))
 )
 ThisBuild / homepage := Some(url("https://github.com/etorreborre/specs2"))
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.13.0
+sbt.version=2.0.7

--- a/project/depends.scala
+++ b/project/depends.scala
@@ -1,6 +1,5 @@
 import sbt._
 import Keys._
-import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport._
 
@@ -16,32 +15,35 @@ object depends {
     Seq("org.scalaz" %% "scalaz-core",
         "org.scalaz" %% "scalaz-effect").map(_ % scalazVersion)
 
+  // scalaz-concurrent is only published for the JVM, so the JS and Native
+  // projects keep using the JVM artifact as they did with sbt 1
   def scalazConcurrent(scalazVersion: String) =
-    "org.scalaz" %% "scalaz-concurrent" % scalazVersion
+    ("org.scalaz" %% "scalaz-concurrent" % scalazVersion).withPlatformOpt(Some("jvm"))
 
   def jvmTest =
     libraryDependencies ++= Seq(
       "org.scala-sbt" % "test-interface" % "1.0",
-      "org.portable-scala" %%% "portable-scala-reflect" % "1.1.3",
+      "org.portable-scala" %% "portable-scala-reflect" % "1.1.3",
       "org.scala-js" %% "scalajs-stubs" % "1.1.0" % "provided")
 
   def jsTest =
     Seq(libraryDependencies ++= Seq(
-      "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion,
-      "org.portable-scala" %%% "portable-scala-reflect" % "1.1.3"),
+      // scalajs-test-interface is published without a platform suffix
+      ("org.scala-js" %% "scalajs-test-interface" % scalaJSVersion).withPlatformOpt(Some("jvm")),
+      "org.portable-scala" %% "portable-scala-reflect" % "1.1.3"),
         Test / scalaJSStage := FastOptStage) ++ jsMacrotaskExecutor
 
   def jsMacrotaskExecutor =
-    Seq(libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.1")
+    Seq(libraryDependencies += "org.scala-js" %% "scala-js-macrotask-executor" % "1.1.1")
 
   def nativeTest =
     Seq(libraryDependencies ++= Seq(
-    "org.scala-native" %%% "test-interface" % nativeVersion,
-    "org.portable-scala" %%% "portable-scala-reflect" % "1.1.3"
+    "org.scala-native" %% "test-interface" % nativeVersion,
+    "org.portable-scala" %% "portable-scala-reflect" % "1.1.3"
     ))
 
   def scalaParser = Def.setting {
-    Seq("org.scala-lang.modules" %%% "scala-parser-combinators" % {
+    Seq("org.scala-lang.modules" %% "scala-parser-combinators" % {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, 12)) => "1.1.2"
         case _             => "2.4.0"
@@ -49,7 +51,7 @@ object depends {
     })
   }
   def scalaParserNative = Def.setting {
-    Seq("org.scala-lang.modules" %%% "scala-parser-combinators" % "2.4.0")
+    Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "2.4.0")
   }
 
   def scalaXml = "org.scala-lang.modules" %% "scala-xml" % "2.4.0"
@@ -63,7 +65,7 @@ object depends {
   lazy val tagsoup = "org.ccil.cowan.tagsoup" % "tagsoup" % "1.2.1"
 
   lazy val scalacheck = Def.setting {
-    "org.scalacheck" %%% "scalacheck" % "1.19.0"
+    "org.scalacheck" %% "scalacheck" % "1.19.0"
   }
 
 }


### PR DESCRIPTION
Supersedes #1623. Scala Steward's bare `sbt.version=2.0.7` bump cannot work on its own: sbt 2 changes enough of the build API that the definition has to be migrated with it, and it requires JDK 17.

## What sbt 2 required

**`%%%` no longer exists.** `sbt-platform-deps` only ever existed to provide `%%%`, and it is deliberately not published for sbt 2 — `%%` is platform-aware there, as the [sbt-crossproject README](https://github.com/portable-scala/sbt-crossproject#readme) now states. The `ide-skip-project` hint read `platformDepsCrossVersion` from that plugin; it now reads sbt 2's own `platform` setting, which is defined for every project (`crossProjectPlatform` would not work here, since these settings also apply to plain projects like `html` and `tests`).

**`coreDefaultSettings` had to go.** `commonSettings` started with `coreDefaultSettings ++ …`, which every project already has. Harmless duplication on sbt 1; on sbt 2 it re-applies the old path layout and puts build outputs outside `target/out`, which sbt 2's task cache rejects.

**`test` is now incremental and returns a `TestResult`.** `X/test` delegates to `testQuick`, so it can silently run nothing — the workflow now runs `testOnly *`, which is an explicit selection and still accepts the specs2 args.

**Task results must be serialisable to be cached**, hence `Def.uncached` for `packagedArtifacts`.

**Two type changes:** `licenses` holds `License` values rather than `(String, URL)` pairs (and takes a `URI`), and `ghpagesPrivateMappings` yields `HashedVirtualFileRef`s, which need `fileConverter` before `IO.copy` can take them.

## The JDK 17 consequence

sbt 2 refuses to start below JDK 17, so **this branch loses its temurin@11 coverage** — there is no configuration that keeps both. That is the significant decision in this PR, not the sbt bump itself.

It has one concrete casualty. `specs2-markdown` uses pegdown 1.6.0 → parboiled 1.x, which reflects into `ClassLoader` internals that JDK 16+ encapsulates:

```
Error creating extended parser class: Could not determine whether class
'org.pegdown.Parser$$parboiled' has already been loaded
```

The forked test JVM now runs with `--add-opens java.base/java.lang=ALL-UNNAMED`, which fixes it. (`main` does not have this problem because it replaced pegdown with flexmark.)

This branch's publish job is gated on `refs/heads/main`, so released artifacts are not affected by the CI JDK. Note there is no `-release` flag in the build, so anyone cutting a 4.x release locally on a newer JDK will produce class files targeting it — worth deciding separately if JDK 11 users still matter.

## Dependencies pinned to their JVM artifacts

sbt 2 applies the platform suffix from the project's platform axis independently of `crossVersion`, so `%%` now asks for the platform variant where sbt 1 silently used the JVM one. Two are pinned with `withPlatformOpt(Some("jvm"))` to keep resolution exactly as it was:

- **`scalaz-concurrent`** — only ever published for the JVM, no `_sjs1` or `_native0.5` artifact exists.
- **`cats-core` / `cats-effect`** — these *do* publish JS and Native artifacts, and picking them up breaks compilation because `unsafeRunSync` does not exist on Scala.js. That means the JS cats module has been built against the JVM cats-effect all along; **this PR preserves that rather than fixing it**, since the real fix changes a published module.

## Verification

Run locally on JDK 21, **both** cross-built Scala versions. Counts are identical to the last green sbt 1 run on this branch ([2.13](https://github.com/etorreborre/specs2/actions/runs/32500101873), [2.12](https://github.com/etorreborre/specs2/actions/runs/32500101873)):

| | 2.13.18 | 2.12.21 |
|---|---|---|
| sbt 1 (temurin@11) | 1072 passed | 1072 passed |
| sbt 2 (this branch) | 1071 passed, 1 failed\* | 1071 passed, 1 failed\* |

Plus an identical distribution across the other 40 modules (`1, 5×3, 6, 9, 10, 14, 17, 22, 26, 29, 65, 72, 102, 325×2, 745`).

\* The single failure is `org.specs2.control.ExecutableSpec`, which shells out to `git tag`. I ran these in a jj workspace, which has no `.git` directory — `fatal: not a git repository`. It passes on a normal checkout; CI here will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
