### PR TITLE
Fix the cats JS build and declare the workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
   push:
     branches: ['**']
 
+permissions: read-all
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -58,6 +60,8 @@ jobs:
         scala: [3.3.8]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout current branch (full)
         uses: actions/checkout@v7

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,16 @@ lazy val specs2 = project.in(file(".")).
     ThisBuild / githubWorkflowArtifactUpload := false,
     ThisBuild / githubWorkflowUseSbtThinClient := false,
     ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17")),
+    // do not let the jobs inherit whatever the repository defaults happen to be
+    ThisBuild / githubWorkflowPermissions := Some(Permissions.ReadAll),
+    // the publish job pushes the generated website to the gh-pages branch
+    ThisBuild / githubWorkflowGeneratedCI ~= {
+      _.map {
+        case job if job.id == "publish" =>
+          job.copy(permissions = Some(Permissions.Specify(Map(PermissionScope.Contents -> PermissionValue.Write))))
+        case job => job
+      }
+    },
     ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("testOnly * -- xonly exclude ci"), name = Some("Build project"))),
     // scalacheck 1.19.0 was built against scala-native 0.5.8; allow eviction to 0.5.12
     ThisBuild / libraryDependencySchemes += "org.scala-native" % "test-interface_native0.5_3" % "always",

--- a/build.sbt
+++ b/build.sbt
@@ -68,12 +68,9 @@ def commonJvmSettings =
 lazy val cats = crossProject(JSPlatform, JVMPlatform).in(file("cats")).
   settings(
     commonSettings,
-    // the JVM artifacts are used on every platform, as they were with sbt 1:
-    // the JS and Native builds of cats-effect do not expose unsafeRunSync,
-    // which IOMatchers needs
     libraryDependencies ++= Seq(
-      ("org.typelevel" %% "cats-core" % catsVersion).withPlatformOpt(Some("jvm")),
-      ("org.typelevel" %% "cats-effect" % catsEffectVersion).withPlatformOpt(Some("jvm"))
+      "org.typelevel" %% "cats-core" % catsVersion,
+      "org.typelevel" %% "cats-effect" % catsEffectVersion
     ),
     name := "specs2-cats"
   ).

--- a/cats/jvm/src/main/scala/org/specs2/matcher/IOMatchers.scala
+++ b/cats/jvm/src/main/scala/org/specs2/matcher/IOMatchers.scala
@@ -1,0 +1,24 @@
+package org.specs2.matcher
+
+import cats.effect.IO
+
+import scala.concurrent.duration.FiniteDuration
+
+trait IOMatchers extends RunTimedMatchers[IO] {
+
+  import cats.effect.unsafe.implicits.global
+
+  protected def runWithTimeout[A](fa: IO[A], d: FiniteDuration): A = fa.timeout(d).unsafeRunSync()
+  protected def runAwait[A](fa: IO[A]) : A = fa.unsafeRunSync()
+
+  protected[specs2] override def attemptRun[T](check: ValueCheck[T], duration: Option[FiniteDuration]): IOMatcher[T] =
+    IOMatcher(check, duration)
+
+  case class IOMatcher[T](check: ValueCheck[T], duration: Option[FiniteDuration])
+      extends TimedMatcher[T](check, duration) {
+    def checkIOWithDuration[S <: IO[T]](e: Expectable[S], d: FiniteDuration): MatchResult[S] =
+      checkWithDuration(e, d)
+    def checkIO[S <: IO[T]](e: Expectable[S]) = checkAwait(e)
+  }
+
+}

--- a/cats/shared/src/main/scala/org/specs2/matcher/RunTimedMatchers.scala
+++ b/cats/shared/src/main/scala/org/specs2/matcher/RunTimedMatchers.scala
@@ -1,6 +1,5 @@
 package org.specs2.matcher
 
-import cats.effect.IO
 import org.specs2.matcher.ValueChecks.valueIsTypedValueCheck
 import org.specs2.matcher.describe.Diffable
 
@@ -70,23 +69,4 @@ trait RunTimedMatchers[F[_]] {
     def withValue(t: T)(implicit di: Diffable[T]): TimedMatcher[T] =
       timedMatcher.withValue(valueIsTypedValueCheck(t))
   }
-}
-
-trait IOMatchers extends RunTimedMatchers[IO] {
-
-  import cats.effect.unsafe.implicits.global
-
-  protected def runWithTimeout[A](fa: IO[A], d: FiniteDuration): A = fa.timeout(d).unsafeRunSync()
-  protected def runAwait[A](fa: IO[A]) : A = fa.unsafeRunSync()
-
-  protected[specs2] override def attemptRun[T](check: ValueCheck[T], duration: Option[FiniteDuration]): IOMatcher[T] =
-    IOMatcher(check, duration)
-
-  case class IOMatcher[T](check: ValueCheck[T], duration: Option[FiniteDuration])
-      extends TimedMatcher[T](check, duration) {
-    def checkIOWithDuration[S <: IO[T]](e: Expectable[S], d: FiniteDuration): MatchResult[S] =
-      checkWithDuration(e, d)
-    def checkIO[S <: IO[T]](e: Expectable[S]) = checkAwait(e)
-  }
-
 }


### PR DESCRIPTION
Follow-ups to #1626, kept out of that PR so the sbt 2 migration can be taken on its own. **Based on `sbt-2-cross`** — merge #1626 first.

## 1. Build the cats matchers for the JVM only

`IOMatchers` calls `unsafeRunSync`, which does not exist in the Scala.js build of cats-effect. #1626 kept `cats-core` and `cats-effect` pinned to their JVM artifacts to preserve sbt 1's behaviour, which meant `specs2-cats_sjs1_3` depended on a JVM jar and would fail at link time for anyone actually using it from Scala.js.

`IOMatchers.scala` held two independent things, so they are now separate files:

- `cats/shared/…/RunTimedMatchers.scala` — `RunTimedMatchers[F[_]]`, platform independent, unchanged
- `cats/jvm/…/IOMatchers.scala` — the `IOMatchers` trait that needs `unsafeRunSync`

`IOMatchersSpec` was already a JVM-only test, so JVM-only was the original intent. With the split in place the `withPlatformOpt(Some("jvm"))` pins are gone and **cats resolves its own JS artifact**.

`scalaz-concurrent` stays pinned — it has never been published for anything but the JVM, so there is no platform artifact to resolve.

## 2. Declare the workflow token permissions

Flagged by CodeRabbit on #1625: the generated workflow has no `permissions:` block, so its jobs inherit the repository or organisation defaults.

```yaml
permissions: read-all      # workflow default
...
  publish:
    permissions:
      contents: write      # pushes the website to gh-pages
```

`read-all` rather than a narrow `contents: read`, because the build jobs also use `actions/cache`; the publish job needs `contents: write` for the gh-pages deploy, so a blanket read-only default would break releases.

## Verification

`githubWorkflowCheck` passes and the full suite is unchanged from #1626 and from the last green sbt 1 run: `1, 10, 14, 17, 22×3, 26, 29, 56, 102, 324×2, 677, 907`, 0 failed, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
