### PR TITLE
Declare the workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ on:
     branches: ['**']
     tags: [SPECS2-*]
 
+permissions: read-all
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -62,6 +64,8 @@ jobs:
         scala: [3.3.8]
         java: [temurin@21]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout current branch (full)
         uses: actions/checkout@v7

--- a/build.sbt
+++ b/build.sbt
@@ -491,6 +491,16 @@ lazy val testJsSettings = Seq(
 lazy val releaseSettings: Seq[Setting[?]] = Seq(
   ThisBuild / versionScheme := Some("early-semver"),
   ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("21")),
+  // do not let the jobs inherit whatever the repository defaults happen to be
+  ThisBuild / githubWorkflowPermissions := Some(Permissions.ReadAll),
+  // the publish job pushes the generated website to the gh-pages branch
+  ThisBuild / githubWorkflowGeneratedCI ~= {
+    _.map {
+      case job if job.id == "publish" =>
+        job.copy(permissions = Some(Permissions.Specify(Map(PermissionScope.Contents -> PermissionValue.Write))))
+      case job => job
+    }
+  },
   ThisBuild / githubWorkflowArtifactUpload := false,
   ThisBuild / githubWorkflowBuildPreamble ++= List(
     WorkflowStep.Sbt(List("scalafmtCheckAll"), name = Some("Check formatting ✔"))


### PR DESCRIPTION
Follow-up to #1625, kept out of that PR so the sbt 2 migration can be taken on its own. **Based on `sbt-2`** — merge #1625 first.

Flagged by CodeRabbit on #1625: the generated workflow has no `permissions:` block, so its jobs inherit the repository or organisation defaults, and the `sbt` steps run repository-controlled code after checkout.

`sbt-github-actions` 0.31.0 exposes `githubWorkflowPermissions`, so this is declared in the build rather than patched into the generated yaml:

```yaml
permissions: read-all      # workflow default
...
  publish:
    permissions:
      contents: write      # pushes the website to gh-pages
```

Two deliberate choices:

- **`read-all` rather than a narrow `contents: read`.** The build and native jobs also use `actions/cache`; over-restricting there gives you a workflow that still looks green while silently doing less.
- **The publish job keeps `contents: write`.** It deploys the generated website to the `gh-pages` branch, so a blanket read-only default would break releases. `ci-release` itself needs nothing from the GitHub token.

## Verification

`githubWorkflowCheck`, `scalafmtCheckAll` and the full suite all pass, with test counts unchanged from #1625: `925, 717, 632, 384, 383, 103, 33, 29, 28, 22×3, 20, 17, 10`, 0 failed, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
