### PR TITLE
Fix the cats JS build, keep JDK 11 artifacts, declare the workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
   push:
     branches: ['**']
 
+permissions: read-all
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -58,6 +60,8 @@ jobs:
         scala: [2.13.18]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout current branch (full)
         uses: actions/checkout@v7

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,16 @@ lazy val specs2 = project.in(file(".")).
     ThisBuild / githubWorkflowArtifactUpload := false,
     ThisBuild / githubWorkflowUseSbtThinClient := false,
     ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17")),
+    // do not let the jobs inherit whatever the repository defaults happen to be
+    ThisBuild / githubWorkflowPermissions := Some(Permissions.ReadAll),
+    // the publish job pushes the generated website to the gh-pages branch
+    ThisBuild / githubWorkflowGeneratedCI ~= {
+      _.map {
+        case job if job.id == "publish" =>
+          job.copy(permissions = Some(Permissions.Specify(Map(PermissionScope.Contents -> PermissionValue.Write))))
+        case job => job
+      }
+    },
     ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("testOnly * -- xonly exclude ci"), name = Some("Build project"))),
     // scalacheck 1.19.0 was built against scala-native 0.5.8; allow eviction to 0.5.12
     ThisBuild / libraryDependencySchemes += "org.scala-native" % "test-interface_native0.5_2.13" % "always",

--- a/build.sbt
+++ b/build.sbt
@@ -101,10 +101,9 @@ lazy val analysisNative = analysis.native
 lazy val cats = crossProject(JSPlatform, JVMPlatform, NativePlatform).in(file("cats")).
   settings(
     commonSettings,
-    // the JVM artifacts are used on every platform, as they were with sbt 1
     libraryDependencies ++= Seq(
-      ("org.typelevel" %% "cats-core" % catsVersion).withPlatformOpt(Some("jvm")),
-      ("org.typelevel" %% "cats-effect" % catsEffectVersion).withPlatformOpt(Some("jvm"))
+      "org.typelevel" %% "cats-core" % catsVersion,
+      "org.typelevel" %% "cats-effect" % catsEffectVersion
     ),
     name := "specs2-cats"
   ).

--- a/build.sbt
+++ b/build.sbt
@@ -414,6 +414,9 @@ lazy val compilationSettings = Seq(
       (Compile / sourceDirectory).value / s"scala-scalaz-7.1.x",
       (Test / test / sourceDirectory).value / s"scala-scalaz-7.1.x"),
   maxErrors := 20,
+  // the build runs on JDK 17 but the artifacts stay usable on JDK 11
+  Compile / scalacOptions ++=
+    (if (platform.value == "jvm") Seq("-release", "11") else Nil),
   Compile / scalacOptions ++=
     Seq(
       "-Xlint",

--- a/cats/jvm/src/main/scala/org/specs2/matcher/IOMatchers.scala
+++ b/cats/jvm/src/main/scala/org/specs2/matcher/IOMatchers.scala
@@ -1,0 +1,24 @@
+package org.specs2.matcher
+
+import cats.effect.IO
+
+import scala.concurrent.duration.FiniteDuration
+
+trait IOMatchers extends RunTimedMatchers[IO] {
+
+  import cats.effect.unsafe.implicits.global
+
+  protected def runWithTimeout[A](fa: IO[A], d: FiniteDuration): A = fa.timeout(d).unsafeRunSync
+  protected def runAwait[A](fa: IO[A]) : A = fa.unsafeRunSync
+
+  protected[specs2] override def attemptRun[T](check: ValueCheck[T], duration: Option[FiniteDuration]): IOMatcher[T] =
+    IOMatcher(check, duration)
+
+  case class IOMatcher[T](check: ValueCheck[T], duration: Option[FiniteDuration])
+      extends TimedMatcher[T](check, duration) {
+    def checkIOWithDuration[S <: IO[T]](e: Expectable[S], d: FiniteDuration): MatchResult[S] =
+      checkWithDuration(e, d)
+    def checkIO[S <: IO[T]](e: Expectable[S]) = checkAwait(e)
+  }
+
+}

--- a/cats/shared/src/main/scala/org/specs2/matcher/RunTimedMatchers.scala
+++ b/cats/shared/src/main/scala/org/specs2/matcher/RunTimedMatchers.scala
@@ -1,6 +1,5 @@
 package org.specs2.matcher
 
-import cats.effect.IO
 import org.specs2.matcher.ValueChecks.valueIsTypedValueCheck
 import org.specs2.matcher.describe.Diffable
 
@@ -70,23 +69,4 @@ trait RunTimedMatchers[F[_]] {
     def withValue(t: T)(implicit di: Diffable[T]): TimedMatcher[T] =
       timedMatcher.withValue(valueIsTypedValueCheck(t))
   }
-}
-
-trait IOMatchers extends RunTimedMatchers[IO] {
-
-  import cats.effect.unsafe.implicits.global
-
-  protected def runWithTimeout[A](fa: IO[A], d: FiniteDuration): A = fa.timeout(d).unsafeRunSync
-  protected def runAwait[A](fa: IO[A]) : A = fa.unsafeRunSync
-
-  protected[specs2] override def attemptRun[T](check: ValueCheck[T], duration: Option[FiniteDuration]): IOMatcher[T] =
-    IOMatcher(check, duration)
-
-  case class IOMatcher[T](check: ValueCheck[T], duration: Option[FiniteDuration])
-      extends TimedMatcher[T](check, duration) {
-    def checkIOWithDuration[S <: IO[T]](e: Expectable[S], d: FiniteDuration): MatchResult[S] =
-      checkWithDuration(e, d)
-    def checkIO[S <: IO[T]](e: Expectable[S]) = checkAwait(e)
-  }
-
 }


### PR DESCRIPTION
Follow-ups to #1627, kept out of that PR so the sbt 2 migration can be taken on its own. **Based on `sbt-2-4x`** — merge #1627 first. Three separate commits.

## 1. Build the cats matchers for the JVM only

`IOMatchers` calls `unsafeRunSync`, which does not exist in the Scala.js or Scala Native builds of cats-effect. #1627 kept `cats-core` and `cats-effect` pinned to their JVM artifacts to preserve sbt 1's behaviour, which meant the JS and Native cats modules depended on a JVM jar.

`IOMatchers.scala` held two independent things, so they are now separate files:

- `cats/shared/…/RunTimedMatchers.scala` — `RunTimedMatchers[F[_]]`, platform independent, unchanged
- `cats/jvm/…/IOMatchers.scala` — the `IOMatchers` trait that needs `unsafeRunSync`

`IOMatchersSpec` was already a JVM-only test, so JVM-only was the original intent. With the split in place the `withPlatformOpt(Some("jvm"))` pins are gone and **cats resolves its own artifact on each platform**.

`scalaz-concurrent` stays pinned — it has never been published for anything but the JVM.

## 2. Keep the artifacts compatible with JDK 11

#1627 has to move CI to temurin@17 because sbt 2 will not start below it. There is no `-release` flag in this build, so the bytecode level of anything compiled here would quietly follow the JDK — a real change for a maintenance branch whose users may still be on JDK 11.

`-release 11` restores what temurin@11 was giving implicitly. It is scoped to the JVM projects via `platform.value == "jvm"`, since it is a bytecode-target flag with no meaning for the JS or Native compilers.

Worth noting: **it compiles with no errors**, so nothing in the main sources actually reaches past the JDK 11 API. The guarantee is real, not just declared.

## 3. Declare the workflow token permissions

Flagged by CodeRabbit on #1625: the generated workflow has no `permissions:` block, so its jobs inherit the repository or organisation defaults.

```yaml
permissions: read-all      # workflow default
...
  publish:
    permissions:
      contents: write      # pushes the website to gh-pages
```

`read-all` rather than a narrow `contents: read`, because the build jobs also use `actions/cache`; the publish job needs `contents: write` for the gh-pages deploy.

## Verification

Full suite run locally on JDK 21 with all three commits applied. Counts unchanged from #1627 and from the last green sbt 1 run: `1072` overall plus `1, 5×3, 6, 9, 10, 14, 17, 22, 26, 29, 65, 72, 102, 325×2, 745`.

The one local failure is `org.specs2.control.ExecutableSpec`, which shells out to `git tag`; I ran this in a jj workspace, which has no `.git` directory. It passed in CI on #1627 and will here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
